### PR TITLE
feat: [sc-26069] NameGraph: tokenized names returned from collections are not tokenized

### DIFF
--- a/namegraph/xcollections/generator_matcher.py
+++ b/namegraph/xcollections/generator_matcher.py
@@ -289,7 +289,7 @@ class CollectionMatcherForGenerator(CollectionMatcher):
             max_recursive_related_collections: int
     ) -> tuple[dict, dict]:
 
-        fields = ['data.collection_name', 'template.top10_names.normalized_name',
+        fields = ['data.collection_name', 'template.top10_names.tokenized_name',
                   'metadata.members_count', 'name_generator.related_collections', 'data.archived']
 
         try:
@@ -324,7 +324,8 @@ class CollectionMatcherForGenerator(CollectionMatcher):
             'collection_id': response['_id'],
             'collection_title': response['_source']['data']['collection_name'],
             'collection_members_count': response['_source']['metadata']['members_count'],
-            'top_members': [item['normalized_name'] for item in response['_source']['template']['top10_names']],
+            'top_members_tokenized_names': [
+                item['tokenized_name'] for item in response['_source']['template']['top10_names']],
             'related_collections': related_collections[:max_recursive_related_collections]
         }
 

--- a/namegraph/xcollections/generator_matcher.py
+++ b/namegraph/xcollections/generator_matcher.py
@@ -225,7 +225,7 @@ class CollectionMatcherForGenerator(CollectionMatcher):
 
             if (number_of_names <= params.max_sample_size) {
                 return params._source.data.names.stream()
-                    .map(n -> n.normalized_name)
+                    .map(n -> n.tokenized_name)
                     .collect(Collectors.toList())
             }
 
@@ -233,7 +233,7 @@ class CollectionMatcherForGenerator(CollectionMatcher):
                 Collections.shuffle(params._source.data.names, random);
                 return params._source.data.names.stream()
                     .limit(params.max_sample_size)
-                    .map(n -> n.normalized_name)
+                    .map(n -> n.tokenized_name)
                     .collect(Collectors.toList());
             }
 
@@ -244,14 +244,14 @@ class CollectionMatcherForGenerator(CollectionMatcher):
                 set.add(index);
             }
 
-            return set.stream().map(i -> params._source.data.names[i].normalized_name).collect(Collectors.toList());
+            return set.stream().map(i -> params._source.data.names[i].tokenized_name).collect(Collectors.toList());
         """
 
         query_params = ElasticsearchQueryBuilder() \
             .set_term('_id', collection_id) \
             .include_fields(fields) \
             .set_source(False) \
-            .include_script_field(name='sampled_members',
+            .include_script_field(name='sampled_members_tokenized_names',
                                   script=sampling_script,
                                   lang='painless',
                                   params={'seed': seed, 'max_sample_size': max_sample_size}) \
@@ -278,7 +278,7 @@ class CollectionMatcherForGenerator(CollectionMatcher):
         result = {
             'collection_id': hit['_id'],
             'collection_title': hit['fields']['data.collection_name'][0],
-            'sampled_members': hit['fields']['sampled_members']
+            'sampled_members_tokenized_names': tuple(hit['fields']['sampled_members_tokenized_names'])
         }
 
         return result, es_response_metadata

--- a/namegraph/xcollections/generator_matcher.py
+++ b/namegraph/xcollections/generator_matcher.py
@@ -325,7 +325,7 @@ class CollectionMatcherForGenerator(CollectionMatcher):
             'collection_title': response['_source']['data']['collection_name'],
             'collection_members_count': response['_source']['metadata']['members_count'],
             'top_members_tokenized_names': [
-                item['tokenized_name'] for item in response['_source']['template']['top10_names']],
+                tuple(item['tokenized_name']) for item in response['_source']['template']['top10_names']],
             'related_collections': related_collections[:max_recursive_related_collections]
         }
 
@@ -536,7 +536,7 @@ class CollectionMatcherForGenerator(CollectionMatcher):
             'collection_id': hit['_id'],
             'collection_title': hit['fields']['data.collection_name'][0],
             'collection_members_count': hit['fields']['metadata.members_count'][0],
-            'members': [item['normalized_name'] for item in hit['fields'].get('members', [])]
+            'members_tokenized_names': [tuple(item['tokenized_name']) for item in hit['fields'].get('members', [])]
         }
 
         return result, es_response_metadata

--- a/tests/test_collections_api.py
+++ b/tests/test_collections_api.py
@@ -598,6 +598,27 @@ class TestCorrectConfiguration:
         assert len(response_json['suggestions']) == 0
 
     @mark.integration_test
+    def test_fetch_collection_members_tokenized_names(self, test_test_client):
+        name2labeltokens = {
+            "dualipa.eth": ("dua", "lipa"),
+            "thebeatles.eth": ("the", "beatles"),
+            "davidbowie.eth": ("david", "bowie")
+        }
+
+        response = test_test_client.post("/fetch_collection_members", json={
+            "collection_id": 'ri2QqxnAqZT7',  # Music artists and bands from England
+            "offset": 0,
+            "limit": 10,
+            "metadata": True
+        })
+        assert response.status_code == 200
+        response_json = response.json()
+        for item in response_json['suggestions']:
+            assert ''.join(item['tokenized_label']) == item['name'].removesuffix('.eth')
+            if item['name'] in name2labeltokens:
+                assert tuple(item['tokenized_label']) == name2labeltokens[item['name']]
+
+    @mark.integration_test
     def test_get_collection_by_id(self, test_test_client):
         # Test successful retrieval
         response = test_test_client.post("/get_collection_by_id", json={

--- a/tests/test_web_api_per_pipeline.py
+++ b/tests/test_web_api_per_pipeline.py
@@ -563,6 +563,29 @@ class TestGrouped:
             assert name['metadata']['pipeline_name'] == 'fetch_top_collection_members'
             assert name['metadata']['collection_id'] == collection_id
 
+    def test_test_fetching_top_collection_members_tokenized(self, test_client):
+        client = test_client
+        collection_id = 'ri2QqxnAqZT7'  # Music artists and bands from England
+
+        name2labeltokens = {
+            "dualipa.eth": ("dua", "lipa"),
+            "thebeatles.eth": ("the", "beatles"),
+            "davidbowie.eth": ("david", "bowie")
+        }
+
+        response = client.post("/fetch_top_collection_members",
+                               json={"collection_id": collection_id})
+
+        assert response.status_code == 200
+        response_json = response.json()
+        assert len(response_json) <= 10
+
+        for item in response_json['suggestions']:
+            assert ''.join(item['tokenized_label']) == item['name'].removesuffix('.eth')
+            if item['name'] in name2labeltokens:
+                assert tuple(item['tokenized_label']) == name2labeltokens[item['name']]
+
+
     @pytest.mark.xfail(reason="Enable when we move filtered collections to use a separate field") # TODO
     def test_fetching_top_collection_members_archived(self, test_client):
         client = test_client

--- a/tests/test_web_api_prod.py
+++ b/tests/test_web_api_prod.py
@@ -1010,6 +1010,25 @@ class TestTokenScramble:
         assert len(names) == 40
 
     @pytest.mark.integration_test
+    @pytest.mark.parametrize("method", ['left-right-shuffle-with-unigrams', 'left-right-shuffle', 'full-shuffle'])
+    def test_tokenized_suggestions(self, prod_test_client, method):
+        client = prod_test_client
+        request_json = {
+            "collection_id": "3OB_f2vmyuyp",  # tropical fruit
+            "method": method,
+            "n_top_members": 10,
+            "max_suggestions": 10,
+            "seed": 0
+        }
+
+        response = client.post("/scramble_collection_tokens", json=request_json)
+        assert response.status_code == 200
+
+        for item in response.json():
+            assert ''.join(item['tokenized_label']) == item['name'].removesuffix('.eth')
+            assert len(item['tokenized_label']) == 2  # all scramble methods concatenate 2 tokens or multi-tokens
+
+    @pytest.mark.integration_test
     @pytest.mark.parametrize(
         "collection_id, method",
         [

--- a/tests/test_web_api_prod.py
+++ b/tests/test_web_api_prod.py
@@ -885,7 +885,7 @@ def test_collection_members_sampling(prod_test_client, collection_id, max_sample
         assert name['metadata']['pipeline_name'] == 'sample_collection_members'
         assert name['metadata']['collection_id'] == collection_id
 
-        assert name['name'] == ''.join(name['tokenized_label'])
+        assert name['name'] == ''.join(name['tokenized_label']).removesuffix('.eth')
 
     # uniqueness
     names = [name['name'] for name in response_json]

--- a/tests/test_web_api_prod.py
+++ b/tests/test_web_api_prod.py
@@ -885,6 +885,8 @@ def test_collection_members_sampling(prod_test_client, collection_id, max_sample
         assert name['metadata']['pipeline_name'] == 'sample_collection_members'
         assert name['metadata']['collection_id'] == collection_id
 
+        assert name['name'] == ''.join(name['tokenized_label'])
+
     # uniqueness
     names = [name['name'] for name in response_json]
     assert len(names) == len(set(names))

--- a/tests/test_web_api_prod.py
+++ b/tests/test_web_api_prod.py
@@ -885,7 +885,7 @@ def test_collection_members_sampling(prod_test_client, collection_id, max_sample
         assert name['metadata']['pipeline_name'] == 'sample_collection_members'
         assert name['metadata']['collection_id'] == collection_id
 
-        assert name['name'] == ''.join(name['tokenized_label']).removesuffix('.eth')
+        assert name['name'].removesuffix('.eth') == ''.join(name['tokenized_label'])
 
     # uniqueness
     names = [name['name'] for name in response_json]

--- a/web_api.py
+++ b/web_api.py
@@ -625,13 +625,13 @@ async def fetch_collection_members(fetch_command: FetchCollectionMembersRequest)
     )
 
     members = []
-    for name in result['members']:
-        obj = GeneratedName(tokens=(name,),
-                          pipeline_name='fetch_collection_members',
-                          collection_id=result['collection_id'],
-                          collection_title=result['collection_title'],
-                          grouping_category='related',
-                          applied_strategies=[])
+    for tokenized_name in result['members_tokenized_names']:
+        obj = GeneratedName(tokens=tokenized_name,
+                            pipeline_name='fetch_collection_members',
+                            collection_id=result['collection_id'],
+                            collection_title=result['collection_title'],
+                            grouping_category='related',
+                            applied_strategies=[])
         obj.interpretation = []
         members.append(obj)
 

--- a/web_api.py
+++ b/web_api.py
@@ -363,8 +363,8 @@ async def fetch_top_collection_members(fetch_top10_command: Top10CollectionMembe
     )
 
     top_members = []
-    for name in result['top_members']:
-        obj = GeneratedName(tokens=(name,),
+    for tokenized_name in result['top_members_tokenized_names']:
+        obj = GeneratedName(tokens=tokenized_name,
                             pipeline_name='fetch_top_collection_members',
                             collection_id=result['collection_id'],
                             collection_title=result['collection_title'],

--- a/web_api.py
+++ b/web_api.py
@@ -336,8 +336,8 @@ async def sample_collection_members(sample_command: SampleCollectionMembers):
     )
 
     sampled_members = []
-    for name in result['sampled_members']:
-        obj = GeneratedName(tokens=(name,),
+    for tokenized_name in result['sampled_members_tokenized_names']:
+        obj = GeneratedName(tokens=tokenized_name,
                             pipeline_name='sample_collection_members',
                             collection_id=result['collection_id'],
                             collection_title=result['collection_title'],

--- a/web_api.py
+++ b/web_api.py
@@ -395,8 +395,8 @@ async def scramble_collection_tokens(scramble_command: ScrambleCollectionTokens)
     )
 
     suggestions = []
-    for name in result['token_scramble_suggestions']:
-        obj = GeneratedName(tokens=(name,),
+    for tokenized_name in result['token_scramble_tokenized_suggestions']:
+        obj = GeneratedName(tokens=tokenized_name,
                             pipeline_name='scramble_collection_tokens',
                             collection_id=result['collection_id'],
                             collection_title=result['collection_title'],


### PR DESCRIPTION
Story details: https://app.shortcut.com/ps-web3/story/26069

TODO:
- [x] fix in `sample_collection_members` endpoint
- [x] fix in `fetch_top_collection_members` endpoint
- [x] fix in `scramble_collection_tokens` endpoint
- [x] fix in `fetch_collection_members` endpoint