### PR TITLE
feat: [sc-26070] Disable adding ".eth" suffix to suggestions

### DIFF
--- a/collection_models.py
+++ b/collection_models.py
@@ -1,15 +1,15 @@
 from datetime import datetime
 from typing import Optional, Literal, Union
-from namegraph.xcollections.query_builder import SortOrder
 from pydantic import BaseModel, Field, PositiveInt, field_validator
 from pydantic_core.core_schema import FieldValidationInfo
 
+from namegraph.xcollections.query_builder import SortOrder
 from models import UserInfo, Metadata, RecursiveRelatedCollection
 
 
-class CollectionName(BaseModel):
-    name: str = Field(title='name from a collection')
-    namehash: str = Field(title='namehash of the name')
+class CollectionName(BaseModel):  # todo: change to CollectionLabel
+    name: str = Field(title='label from a collection')  # todo: change to label
+    namehash: str = Field(title='namehash of the name')  # todo: remove namehash (also from the collections code)
 
 
 class Collection(BaseModel):
@@ -163,17 +163,17 @@ class GetCollectionByIdRequest(BaseCollectionRequest):
 # ======== Suggestions from collections ========
 
 class SuggestionFromCollection(BaseModel):
-    name: str = Field(title="name (label) from a collection")
-    tokenized_label: list[str] = Field(title="original tokenization of name (label)")
+    name: str = Field(title="label from a collection")  # todo: change to label
+    tokenized_label: list[str] = Field(title="original tokenization of label")
     metadata: Optional[Metadata] = Field(None, title="information how suggestion was generated",
                                          description="if metadata=False this key is absent")
 
 
 class CollectionWithSuggestions(BaseModel):
     suggestions: list[SuggestionFromCollection] = Field(title='suggestions from a collection')
-    name: str = Field(title='collection title', description='kept for backwards compatibility')  # todo:  remove field if not used
+    name: str = Field(title='collection title', description='kept for backwards compatibility')  # todo:  remove field
     type: Literal['related'] = Field('related', title='category type (always set to \'related\')', 
-                                     description='kept for backwards compatibility')  # todo: remove field if not used
+                                     description='kept for backwards compatibility')  # todo: remove field
     collection_id: str = Field(title='id of the collection')
     collection_title: str = Field(title='title of the collection')
     collection_members_count: int = Field(title='number of members in the collection')
@@ -216,7 +216,7 @@ class ScrambleCollectionTokens(BaseModel):
     n_top_members: int = Field(25, title='number of collection\'s top members to include in scrambling', ge=1)
     max_suggestions: Optional[PositiveInt] = Field(10, title='maximal number of suggestions to generate',
   examples=[10], description='must be a positive integer or null\n* number of generated suggestions will be '
-                             '`max_suggestions` or less (exactly `max_suggestions` if there are enough names)\n'
+                             '`max_suggestions` or less (exactly `max_suggestions` if there are enough members)\n'
                              '* if null, no tokens are repeated')
     seed: int = Field(default_factory=lambda: int(datetime.now().timestamp()),
                       title='seed for random number generator',
@@ -236,3 +236,10 @@ class FetchCollectionMembersRequest(BaseModel):
     metadata: bool = Field(
         True, title='return all the metadata in response'
     )
+
+
+# refactor models plan:
+#  [x] apply easy renamings
+#  [x] separate request forming functions
+#  3. adjust collection models and their request forming functions
+#  4. check josiah renamings

--- a/collection_models.py
+++ b/collection_models.py
@@ -64,9 +64,9 @@ class BaseCollectionSearch(BaseCollectionSearchLimitOffsetSort):
                                         title='number of collections with the same type which are not penalized',
                                         description='* set to null if you want to disable the penalization\n'
                                                     '* if the penalization algorithm is turned on then 3 times more results (than max_related_collections) are retrieved from Elasticsearch')
-    name_diversity_ratio: Optional[float] = Field(None, examples=[0.5], ge=0.0, le=1.0,
+    label_diversity_ratio: Optional[float] = Field(None, examples=[0.5], ge=0.0, le=1.0,
         title='similarity value used for adding penalty to collections with similar labels to other collections',
-        description='* if more than name_diversity_ratio % of the labels have already been used, penalize the collection\n'
+        description='* if more than label_diversity_ratio % of the labels have already been used, penalize the collection\n'
                     '* set to null if you want disable the penalization\n'
                     '* if the penalization algorithm is turned on then 3 times more results (than `max_related_collections`) '
                     'are retrieved from Elasticsearch'

--- a/collection_models.py
+++ b/collection_models.py
@@ -171,9 +171,6 @@ class SuggestionFromCollection(BaseModel):
 
 class CollectionWithSuggestions(BaseModel):
     suggestions: list[SuggestionFromCollection] = Field(title='suggestions from a collection')
-    name: str = Field(title='collection title', description='kept for backwards compatibility')  # todo:  remove field
-    type: Literal['related'] = Field('related', title='category type (always set to \'related\')', 
-                                     description='kept for backwards compatibility')  # todo: remove field
     collection_id: str = Field(title='id of the collection')
     collection_title: str = Field(title='title of the collection')
     collection_members_count: int = Field(title='number of members in the collection')

--- a/collection_models.py
+++ b/collection_models.py
@@ -7,7 +7,7 @@ from models import UserInfo
 
 
 class CollectionName(BaseModel):
-    name: str = Field(title='name with `.eth`')
+    name: str = Field(title='name from a collection')
     namehash: str = Field(title='namehash of the name')
 
 

--- a/collection_models.py
+++ b/collection_models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional, Literal, Union
 from pydantic import BaseModel, Field, PositiveInt, field_validator
-from pydantic_core.core_schema import FieldValidationInfo
+from pydantic_core.core_schema import ValidationInfo
 
 from namegraph.xcollections.query_builder import SortOrder
 from models import UserInfo, Metadata, RecursiveRelatedCollection
@@ -87,13 +87,15 @@ class BaseCollectionSearchWithOther(BaseCollectionSearch):  # instant search, do
                                        '\nif not met, 422 status code is returned')
 
     @field_validator('max_other_collections')
-    def max_other_between_min_other_and_max_total(cls, v: int, info: FieldValidationInfo) -> int:
+    @classmethod
+    def max_other_between_min_other_and_max_total(cls, v: int, info: ValidationInfo) -> int:
         if 'min_other_collections' in info.data and info.data['min_other_collections'] > v:
             raise ValueError('min_other_collections must not be greater than max_other_collections')
         return v
 
     @field_validator('max_total_collections')
-    def max_related_between_min_other_and_max_total(cls, v: int, info: FieldValidationInfo) -> int:
+    @classmethod
+    def max_related_between_min_other_and_max_total(cls, v: int, info: ValidationInfo) -> int:
         if 'max_other_collections' in info.data and v < info.data['max_other_collections']:
             raise ValueError('max_other_collections must not be greater than max_total_collections')
         if 'min_other_collections' in info.data and 'max_related_collections' in info.data and \

--- a/collection_models.py
+++ b/collection_models.py
@@ -166,7 +166,7 @@ class GetCollectionByIdRequest(BaseCollectionRequest):
 
 class SuggestionFromCollection(BaseModel):
     name: str = Field(title="label from a collection")  # todo: change to label
-    tokenized_label: list[str] = Field(title="original tokenization of label")
+    tokenized_label: list[str] = Field(title="suggested tokenization of label")
     metadata: Optional[Metadata] = Field(None, title="information how suggestion was generated",
                                          description="if metadata=False this key is absent")
 

--- a/conf/prod_config_new.yaml
+++ b/conf/prod_config_new.yaml
@@ -172,5 +172,5 @@ collections:
   other_collections_path: data/collections_data/other_collections.json
   collections_limit: 3
   suggestions_limit: 25  # per one collections
-  name_diversity_ratio: 0.5
+  label_diversity_ratio: 0.5
   max_per_type: 2

--- a/conf/test_config_new.yaml
+++ b/conf/test_config_new.yaml
@@ -175,5 +175,5 @@ collections:
   other_collections_path: data/collections_data/other_collections.json
   collections_limit: 3
   suggestions_limit: 25  # per one collections
-  name_diversity_ratio: 0.5
+  label_diversity_ratio: 0.5
   max_per_type: 2

--- a/models.py
+++ b/models.py
@@ -35,8 +35,8 @@ class Metadata(BaseModel):
                                description='label\'s status cached at the time of application startup')
     categories: list[str] = Field(title='domain category',
                                   description='can be either available, taken, recently released or on sale')
-    cached_interesting_score: Optional[float] = Field(title='cached interesting score',
-                                                      description='label\'s interesting score cached at the time of '
+    cached_sort_score: Optional[float] = Field(title='cached sort score',
+                                                      description='label\'s sort score cached at the time of '
                                                                   'application startup')
     applied_strategies: list[list[str]] = Field(
         title="sequence of steps performed in every pipeline that generated the suggestion"
@@ -74,7 +74,7 @@ class Params(BaseModel):
     enable_learning_to_rank: bool = Field(True, title='enable learning to rank',
                                           description='if true, the results will be sorted by '
                                                       'learning to rank algorithm')
-    name_diversity_ratio: Optional[float] = \
+    label_diversity_ratio: Optional[float] = \
         Field(0.5, examples=[0.5], ge=0.0, le=1.0, title='collection diversity parameter based on names',
               description='adds penalty to collections with similar names to other collections\n'
                           'if null, then no penalty will be added')
@@ -130,7 +130,7 @@ class RelatedCategoryParams(BaseModel):
     enable_learning_to_rank: bool = Field(True, title='enable learning to rank',
                                           description='if true, the results will be sorted by '
                                                       'learning to rank algorithm')
-    name_diversity_ratio: Optional[float] = \
+    label_diversity_ratio: Optional[float] = \
         Field(0.5, examples=[0.5], ge=0.0, le=1.0, title='collection diversity parameter based on names',
               description='adds penalty to collections with similar names to other collections\n'
                           'if null, then no penalty will be added')

--- a/models.py
+++ b/models.py
@@ -181,7 +181,7 @@ class Metadata(BaseModel):
 
 
 class Suggestion(BaseModel):
-    name: str = Field(title="suggested similar name (not label)")
+    name: str = Field(title="suggested similar name (or label, in the collection endpoints)")
     tokenized_label: list[str] = Field(title="original tokenization of suggested name's label")
     metadata: Optional[Metadata] = Field(None, title="information how suggestion was generated",
                                          description="if metadata=False this key is absent")

--- a/models.py
+++ b/models.py
@@ -5,6 +5,8 @@ from pydantic.networks import IPvAnyAddress
 from web_api import generator
 
 
+# ======== Shared models ========
+
 class UserInfo(BaseModel):
     user_wallet_addr: Optional[str] = Field(None, title='wallet (public) address of the user',
                                             description='might be null',
@@ -23,6 +25,42 @@ class UserInfo(BaseModel):
     def serialize_user_ip_addr(self, user_ip_addr: IPvAnyAddress, _info) -> str:
         return str(user_ip_addr)
 
+
+class Metadata(BaseModel):
+    pipeline_name: str = Field(title='name of the pipeline, which has produced this suggestion')
+    interpretation: list[str | None] = Field(title='interpretation tags',
+                                             description='list of interpretation tags based on which the '
+                                                         'suggestion has been generated')
+    cached_status: str = Field(title='cached status',
+                               description='name\'s status cached at the time of application startup')
+    categories: list[str] = Field(title='domain category',
+                                  description='can be either available, taken, recently released or on sale')
+    cached_interesting_score: Optional[float] = Field(title='cached interesting score',
+                                                      description='name\'s interesting score cached at the time of '
+                                                                  'application startup')
+    applied_strategies: list[list[str]] = Field(
+        title="sequence of steps performed in every pipeline that generated the suggestion"
+    )
+    collection_title: Optional[str] = Field(
+        title='name of the collection',
+        description='if name has been generated using a collection, '
+                    'then this field would contains its name, else it is null'
+    )
+    collection_id: Optional[str] = Field(
+        title='id of the collection',
+        description='if name has been generated using a collection, '
+                    'then this field would contains its id, else it is null'
+    )
+    grouping_category: Optional[str] = Field(title='grouping category to which this suggestion belongs')
+
+
+class RecursiveRelatedCollection(BaseModel):
+    collection_id: str = Field(title='id of the collection')
+    collection_title: str = Field(title='title of the collection')
+    collection_members_count: int = Field(title='number of members in the collection')
+
+
+# ======== Generator models ========
 
 class Params(BaseModel):
     user_info: Optional[UserInfo] = Field(None, title='information about user making request')
@@ -131,12 +169,6 @@ class GroupedNameRequest(BaseModel):
         title='controls the results of other categories than related (except for "Other Names")')
 
 
-class RecursiveRelatedCollection(BaseModel):
-    collection_id: str = Field(title='id of the collection')
-    collection_title: str = Field(title='title of the collection')
-    collection_members_count: int = Field(title='number of members in the collection')
-
-
 class NameRequest(BaseModel):
     label: str = Field(title='input label', description='cannot contain dots (.)',
                        pattern='^[^.]*$', examples=['zeus'])
@@ -155,37 +187,9 @@ class NameRequest(BaseModel):
                                      description='includes all the parameters for all nodes of the pipeline')
 
 
-class Metadata(BaseModel):
-    pipeline_name: str = Field(title='name of the pipeline, which has produced this suggestion')
-    interpretation: list[str | None] = Field(title='interpretation tags',
-                                             description='list of interpretation tags based on which the '
-                                                         'suggestion has been generated')
-    cached_status: str = Field(title='cached status',
-                               description='name\'s status cached at the time of application startup')
-    categories: list[str] = Field(title='domain category',
-                                  description='can be either available, taken, recently released or on sale')
-    cached_interesting_score: Optional[float] = Field(title='cached interesting score',
-                                                      description='name\'s interesting score cached at the time of '
-                                                                  'application startup')
-    applied_strategies: list[list[str]] = Field(
-        title="sequence of steps performed in every pipeline that generated the suggestion"
-    )
-    collection_title: Optional[str] = Field(
-        title='name of the collection',
-        description='if name has been generated using a collection, '
-                    'then this field would contains its name, else it is null'
-    )
-    collection_id: Optional[str] = Field(
-        title='id of the collection',
-        description='if name has been generated using a collection, '
-                    'then this field would contains its id, else it is null'
-    )
-    grouping_category: Optional[str] = Field(title='grouping category to which this suggestion belongs')
-
-
 class Suggestion(BaseModel):
-    name: str = Field(title="suggested similar name (with the '.eth' suffix)")
-    tokenized_label: list[str] = Field(title="original tokenization of suggested name's label (without the '.eth' suffix)")
+    name: str = Field(title="suggested similar label")  # todo: change to label
+    tokenized_label: list[str] = Field(title="original tokenization of suggested name's label")
     metadata: Optional[Metadata] = Field(None, title="information how suggestion was generated",
                                          description="if metadata=False this key is absent")
 

--- a/models.py
+++ b/models.py
@@ -32,23 +32,23 @@ class Metadata(BaseModel):
                                              description='list of interpretation tags based on which the '
                                                          'suggestion has been generated')
     cached_status: str = Field(title='cached status',
-                               description='name\'s status cached at the time of application startup')
+                               description='label\'s status cached at the time of application startup')
     categories: list[str] = Field(title='domain category',
                                   description='can be either available, taken, recently released or on sale')
     cached_interesting_score: Optional[float] = Field(title='cached interesting score',
-                                                      description='name\'s interesting score cached at the time of '
+                                                      description='label\'s interesting score cached at the time of '
                                                                   'application startup')
     applied_strategies: list[list[str]] = Field(
         title="sequence of steps performed in every pipeline that generated the suggestion"
     )
     collection_title: Optional[str] = Field(
         title='name of the collection',
-        description='if name has been generated using a collection, '
+        description='if label has been generated using a collection, '
                     'then this field would contains its name, else it is null'
     )
     collection_id: Optional[str] = Field(
         title='id of the collection',
-        description='if name has been generated using a collection, '
+        description='if label has been generated using a collection, '
                     'then this field would contains its id, else it is null'
     )
     grouping_category: Optional[str] = Field(title='grouping category to which this suggestion belongs')
@@ -153,7 +153,7 @@ class CategoriesParams(BaseModel):
     model_config = ConfigDict(frozen=True)
 
 
-class GroupedNameRequest(BaseModel):
+class GroupedLabelRequest(BaseModel):
     label: str = Field(title='input label', pattern='^[^.]*$', examples=['zeus'],
                        description='* cannot contain dots (.)'
                                    '\n* if enclosed in double quotes assuming label is pre-tokenized')
@@ -169,7 +169,7 @@ class GroupedNameRequest(BaseModel):
         title='controls the results of other categories than related (except for "Other Names")')
 
 
-class NameRequest(BaseModel):
+class LabelRequest(BaseModel):
     label: str = Field(title='input label', description='cannot contain dots (.)',
                        pattern='^[^.]*$', examples=['zeus'])
     metadata: bool = Field(True, title='return all the metadata in response')
@@ -188,8 +188,8 @@ class NameRequest(BaseModel):
 
 
 class Suggestion(BaseModel):
-    name: str = Field(title="suggested similar label")  # todo: change to label
-    tokenized_label: list[str] = Field(title="original tokenization of suggested name's label")
+    label: str = Field(title="suggested similar label")
+    tokenized_label: list[str] = Field(title="suggested tokenization of label")
     metadata: Optional[Metadata] = Field(None, title="information how suggestion was generated",
                                          description="if metadata=False this key is absent")
 

--- a/namegraph/domains.py
+++ b/namegraph/domains.py
@@ -82,15 +82,15 @@ class Domains(metaclass=Singleton):
             next(reader)
             for row in reader:
                 assert len(row) == 3
-                name, interesting_score, status = row
+                name, sort_score, status = row
                 name = strip_eth(name)
-                interesting_score = float(interesting_score)
+                sort_score = float(sort_score)
                 if status == self.TAKEN or status == self.RECENTLY_RELEASED:
-                    taken[name] = interesting_score
+                    taken[name] = sort_score
                 elif status == self.ON_SALE:
-                    on_sale[name] = interesting_score
+                    on_sale[name] = sort_score
                 elif status == self.AVAILABLE:
-                    available[name] = interesting_score
+                    available[name] = sort_score
 
         return taken, on_sale, available
 
@@ -102,7 +102,7 @@ class Domains(metaclass=Singleton):
         else:
             return self.AVAILABLE
 
-    def get_interesting_score(self, name: GeneratedName) -> Optional[float]:
+    def get_sort_score(self, name: GeneratedName) -> Optional[float]:
         if name.status is None:
             name.status = self.get_name_status(str(name))
 

--- a/namegraph/generation/collection_generator.py
+++ b/namegraph/generation/collection_generator.py
@@ -43,7 +43,7 @@ class CollectionGenerator(NameGenerator):
         self.collection_matcher = CollectionMatcherForGenerator(config)
         self.collections_limit = config.collections.collections_limit
         self.suggestions_limit = config.collections.suggestions_limit
-        self.name_diversity_ratio = config.collections.name_diversity_ratio
+        self.label_diversity_ratio = config.collections.label_diversity_ratio
         self.max_per_type = config.collections.max_per_type
 
     def apply(self, name: InputName, interpretation: Interpretation) -> Iterable[GeneratedName]:
@@ -92,7 +92,7 @@ class CollectionGenerator(NameGenerator):
             tuple(tokens),
             name.strip_eth_namehash_unicode_long_name.strip(),
             max_related_collections=params.get('max_related_collections', self.collections_limit),
-            name_diversity_ratio=params.get('name_diversity_ratio', self.name_diversity_ratio),
+            label_diversity_ratio=params.get('label_diversity_ratio', self.label_diversity_ratio),
             max_per_type=params.get('max_per_type', self.max_per_type),
             limit_names=suggestions_limit,
             enable_learning_to_rank=params.get('enable_learning_to_rank', True),

--- a/namegraph/utils/log.py
+++ b/namegraph/utils/log.py
@@ -61,5 +61,5 @@ class LogEntry:
             'normalized_price': '2.34',  # dummy
             'price_in_user_currency': '3.45',  # dummy
             'categories': self.categories.get_categories(str(suggestion)),
-            'cached_interesting_score': self.domains.get_interesting_score(suggestion)
+            'cached_sort_score': self.domains.get_sort_score(suggestion)
         }

--- a/namegraph/xcollections/api_matcher.py
+++ b/namegraph/xcollections/api_matcher.py
@@ -22,7 +22,7 @@ class CollectionMatcherForAPI(CollectionMatcher):
             max_related_collections: int = 3,
             offset: int = 0,
             sort_order: Literal[SortOrder.AZ, SortOrder.ZA, SortOrder.AI, SortOrder.RELEVANCE] = SortOrder.AI,
-            name_diversity_ratio: Optional[float] = 0.5,
+            label_diversity_ratio: Optional[float] = 0.5,
             max_per_type: Optional[int] = 3,
             limit_names: int = 10,
     ) -> tuple[list[Collection], dict]:
@@ -48,7 +48,7 @@ class CollectionMatcherForAPI(CollectionMatcher):
             'data.collection_keywords^2', 'data.names.normalized_name', 'data.names.tokenized_name'
         ]
 
-        apply_diversity = name_diversity_ratio is not None or max_per_type is not None
+        apply_diversity = label_diversity_ratio is not None or max_per_type is not None
         query_builder = ElasticsearchQueryBuilder() \
             .add_filter('term', {'data.public': True}) \
             .add_filter('term', {'data.archived': False}) \
@@ -94,7 +94,7 @@ class CollectionMatcherForAPI(CollectionMatcher):
                 return collections[:max_related_collections], es_response_metadata
 
             diversified = self._apply_diversity(collections, max_related_collections,
-                                                name_diversity_ratio, max_per_type)
+                                                label_diversity_ratio, max_per_type)
             return diversified, es_response_metadata
         except Exception as ex:
             logger.error(f'Elasticsearch search failed [by-string]', exc_info=True)
@@ -137,7 +137,7 @@ class CollectionMatcherForAPI(CollectionMatcher):
             self,
             collection_id: str,
             max_related_collections: int = 3,
-            name_diversity_ratio: Optional[float] = 0.5,
+            label_diversity_ratio: Optional[float] = 0.5,
             max_per_type: Optional[int] = 3,
             limit_names: Optional[int] = 10,
             sort_order: Literal[SortOrder.AZ, SortOrder.ZA, SortOrder.RELEVANCE] = SortOrder.RELEVANCE,
@@ -177,7 +177,7 @@ class CollectionMatcherForAPI(CollectionMatcher):
             logger.warning(f'more than 1 collection found with id {collection_id}')
 
         # search similar collections
-        apply_diversity = name_diversity_ratio is not None or max_per_type is not None
+        apply_diversity = label_diversity_ratio is not None or max_per_type is not None
 
         query_params = (ElasticsearchQueryBuilder()
                         .add_query(found_collection.title, boolean_clause='should', type_='cross_fields',
@@ -216,7 +216,7 @@ class CollectionMatcherForAPI(CollectionMatcher):
         diversified = self._apply_diversity(
             [found_collection] + collections,
             max_related_collections + 1,
-            name_diversity_ratio,
+            label_diversity_ratio,
             max_per_type
         )
         diversified = [c for c in diversified if c.collection_id != found_collection.collection_id]

--- a/namegraph/xcollections/generator_matcher.py
+++ b/namegraph/xcollections/generator_matcher.py
@@ -22,7 +22,7 @@ class CollectionMatcherForGenerator(CollectionMatcher):
             self,
             tokens: tuple[str, ...],
             max_related_collections: int = 5,
-            name_diversity_ratio: Optional[float] = 0.5,
+            label_diversity_ratio: Optional[float] = 0.5,
             max_per_type: Optional[int] = 3,
             limit_names: int = 10,
             enable_learning_to_rank: bool = True,
@@ -46,7 +46,7 @@ class CollectionMatcherForGenerator(CollectionMatcher):
             'data.collection_keywords^2', 'data.names.normalized_name', 'data.names.tokenized_name'
         ]
 
-        apply_diversity = name_diversity_ratio is not None or max_per_type is not None
+        apply_diversity = label_diversity_ratio is not None or max_per_type is not None
         query_builder = ElasticsearchQueryBuilder() \
             .add_filter('term', {'data.archived': False}) \
             .add_limit(max_related_collections if not apply_diversity else max_related_collections * 3) \
@@ -89,7 +89,7 @@ class CollectionMatcherForGenerator(CollectionMatcher):
             diversified = self._apply_diversity(
                 collections,
                 max_related_collections,
-                name_diversity_ratio,
+                label_diversity_ratio,
                 max_per_type
             )
             return diversified, es_response_metadata
@@ -145,7 +145,7 @@ class CollectionMatcherForGenerator(CollectionMatcher):
             tokens: tuple[str, ...],
             input_name: str,
             max_related_collections: int = 5,
-            name_diversity_ratio: Optional[float] = 0.5,
+            label_diversity_ratio: Optional[float] = 0.5,
             max_per_type: Optional[int] = 3,
             limit_names: int = 10,
             enable_learning_to_rank: bool = True,
@@ -157,7 +157,7 @@ class CollectionMatcherForGenerator(CollectionMatcher):
                 self._search_for_generator,
                 tokens=tokens,
                 max_related_collections=max_related_collections,
-                name_diversity_ratio=name_diversity_ratio,
+                label_diversity_ratio=label_diversity_ratio,
                 max_per_type=max_per_type,
                 limit_names=limit_names,
                 enable_learning_to_rank=enable_learning_to_rank

--- a/namegraph/xcollections/matcher.py
+++ b/namegraph/xcollections/matcher.py
@@ -61,7 +61,7 @@ class CollectionMatcher(metaclass=Singleton):
             self,
             collections: list[Collection],
             max_limit: int,
-            name_diversity_ratio: Optional[float],
+            label_diversity_ratio: Optional[float],
             max_per_type: Optional[int],
     ) -> list[Collection]:
 
@@ -72,11 +72,11 @@ class CollectionMatcher(metaclass=Singleton):
         used_types = defaultdict(int)  # types cover
 
         for collection in collections:
-            if name_diversity_ratio is not None:
+            if label_diversity_ratio is not None:
                 number_of_covered_names = len(set(collection.names) & used_names)
 
-                # if more than `name_diversity_ratio` of the names have already been used, penalize the collection
-                if number_of_covered_names / len(collection.names) < name_diversity_ratio:
+                # if more than `label_diversity_ratio` of the names have already been used, penalize the collection
+                if number_of_covered_names / len(collection.names) < label_diversity_ratio:
                     used_names.update(collection.names)
                 else:
                     penalized_collections.append((collection.score * 0.8, collection))
@@ -147,7 +147,7 @@ class CollectionMatcher(metaclass=Singleton):
             fields: list[str],
             offset: int = 0,
             sort_order: Literal[SortOrder.AZ, SortOrder.ZA, SortOrder.AI, SortOrder.RELEVANCE] = None,
-            name_diversity_ratio: Optional[float] = None,
+            label_diversity_ratio: Optional[float] = None,
             max_per_type: Optional[int] = None,
             limit_names: int = 10,
     ) -> tuple[list[Collection], dict]:
@@ -155,7 +155,7 @@ class CollectionMatcher(metaclass=Singleton):
         if sort_order == SortOrder.AI:
             sort_order = SortOrder.RELEVANCE
 
-        apply_diversity = name_diversity_ratio is not None or max_per_type is not None
+        apply_diversity = label_diversity_ratio is not None or max_per_type is not None
         query_params = ElasticsearchQueryBuilder() \
             .add_query(query) \
             .add_filter('term', {'data.public': True}) \
@@ -173,5 +173,5 @@ class CollectionMatcher(metaclass=Singleton):
         if not apply_diversity:
             return collections[:max_limit], es_response_metadata
 
-        diversified = self._apply_diversity(collections, max_limit, name_diversity_ratio, max_per_type)
+        diversified = self._apply_diversity(collections, max_limit, label_diversity_ratio, max_per_type)
         return diversified, es_response_metadata

--- a/namegraph/xgenerator.py
+++ b/namegraph/xgenerator.py
@@ -169,7 +169,7 @@ class Generator:
         params['categories_params'] = categories_params
         params['min_total_suggestions'] = min_total_suggestions
         params['max_suggestions'] = 200  # TODO used to limit generators
-        params['name_diversity_ratio'] = categories_params.related.name_diversity_ratio
+        params['label_diversity_ratio'] = categories_params.related.label_diversity_ratio
         params['max_per_type'] = categories_params.related.max_per_type
         params['enable_learning_to_rank'] = categories_params.related.enable_learning_to_rank
 

--- a/research/collections-benchmark/benchmark.py
+++ b/research/collections-benchmark/benchmark.py
@@ -37,7 +37,7 @@ def find_collections_by_string(
         min_other_collections: int = 0,
         max_other_collections: int = 0,
         max_total_collections: int = 15,
-        name_diversity_ratio: float = 0.55,
+        label_diversity_ratio: float = 0.55,
         max_per_type: int = 3,
         limit_names: int = 10,
 ):
@@ -48,7 +48,7 @@ def find_collections_by_string(
         "min_other_collections": min_other_collections,
         "max_other_collections": max_other_collections,
         "max_total_collections": max_total_collections,
-        "name_diversity_ratio": name_diversity_ratio,
+        "label_diversity_ratio": label_diversity_ratio,
         "max_per_type": max_per_type,
         "limit_names": limit_names,
     }
@@ -77,7 +77,7 @@ def find_collections_by_collection(collection_id: str):
         "min_other_collections": 0,
         "max_other_collections": 0,
         "max_total_collections": 10,
-        "name_diversity_ratio": 0.5,
+        "label_diversity_ratio": 0.5,
         "max_per_type": 5,
         "limit_names": 10,
         "sort_order": "AI",
@@ -180,7 +180,7 @@ def benchmark_report(times: dict[str, dict[str, list[float]]]):
 
 
 if __name__ == '__main__':
-    parser = ArgumentParser(description='Benchmark the NameGenerator collections search API')
+    parser = ArgumentParser(description='Benchmark the NameGraph collections search API')
     parser.add_argument('--host', type=str, default='localhost', help='host')
     parser.add_argument('--port', type=int, default=8000, help='port')
     parser.add_argument('--repeats', type=int, default=15, help='repeats')

--- a/research/elasticsearch/search-client-limit-names.py
+++ b/research/elasticsearch/search-client-limit-names.py
@@ -10,7 +10,7 @@ import numpy as np
 def request_generator_http(
         query: str,
         limit: int,
-        name_diversity_ratio: Optional[float],
+        label_diversity_ratio: Optional[float],
         max_per_type: Optional[int],
         limit_names: Optional[int],
         host: str = 'localhost',
@@ -22,7 +22,7 @@ def request_generator_http(
         "min_other_collections": 0,
         "max_other_collections": 0,
         "max_total_collections": limit,
-        "name_diversity_ratio": name_diversity_ratio,
+        "label_diversity_ratio": label_diversity_ratio,
         "max_per_type": max_per_type,
         "limit_names": limit_names,
     }
@@ -35,7 +35,7 @@ def request_generator_http(
 def search_by_all(
         query: str,
         limit: int,
-        name_diversity_ratio: Optional[float],
+        label_diversity_ratio: Optional[float],
         max_per_type: Optional[int],
         limit_names: Optional[int],
         host: str = 'localhost',
@@ -44,7 +44,7 @@ def search_by_all(
     response = request_generator_http(
         query,
         limit,
-        name_diversity_ratio,
+        label_diversity_ratio,
         max_per_type,
         limit_names,
         host=host,
@@ -58,7 +58,7 @@ def search_by_all(
 def search_with_latency(
         query: str,
         limit: int,
-        name_diversity_ratio: Optional[float],
+        label_diversity_ratio: Optional[float],
         max_per_type: Optional[int],
         limit_names: Optional[int],
         host: str = 'localhost',
@@ -67,7 +67,7 @@ def search_with_latency(
     results, latency, took = search_by_all(
         query,
         limit,
-        name_diversity_ratio,
+        label_diversity_ratio,
         max_per_type,
         limit_names,
         host=host,

--- a/research/elasticsearch/search-client.py
+++ b/research/elasticsearch/search-client.py
@@ -10,7 +10,7 @@ import numpy as np
 def request_generator_http(
         query: str,
         limit: int,
-        name_diversity_ratio: Optional[float],
+        label_diversity_ratio: Optional[float],
         max_per_type: Optional[int],
         limit_names: Optional[int],
         host: str = 'localhost',
@@ -22,7 +22,7 @@ def request_generator_http(
         "min_other_collections": 0,
         "max_other_collections": 0,
         "max_total_collections": limit,
-        "name_diversity_ratio": name_diversity_ratio,
+        "label_diversity_ratio": label_diversity_ratio,
         "max_per_type": max_per_type,
         "limit_names": limit_names,
     }
@@ -35,7 +35,7 @@ def request_generator_http(
 def search_by_all(
         query: str,
         limit: int,
-        name_diversity_ratio: Optional[float],
+        label_diversity_ratio: Optional[float],
         max_per_type: Optional[int],
         limit_names: Optional[int],
         host: str = 'localhost',
@@ -44,7 +44,7 @@ def search_by_all(
     response = request_generator_http(
         query,
         limit,
-        name_diversity_ratio,
+        label_diversity_ratio,
         max_per_type,
         limit_names,
         host=host,
@@ -58,7 +58,7 @@ def search_by_all(
 def search_with_latency(
         query: str,
         limit: int,
-        name_diversity_ratio: Optional[float],
+        label_diversity_ratio: Optional[float],
         max_per_type: Optional[int],
         limit_names: Optional[int],
         host: str = 'localhost',
@@ -67,7 +67,7 @@ def search_with_latency(
     results, latency, took = search_by_all(
         query,
         limit,
-        name_diversity_ratio,
+        label_diversity_ratio,
         max_per_type,
         limit_names,
         host=host,

--- a/research/gui/gui.py
+++ b/research/gui/gui.py
@@ -73,7 +73,7 @@ def add_collection(parent_collection_id: str, collection_id: str):
 def call_suggestions_by_category(label: str,
                                  max_recursive_related_collections: int = 3,
                                  max_related_collections: int = 6,
-                                 name_diversity_ratio: float = 0.5,
+                                 label_diversity_ratio: float = 0.5,
                                  max_per_type: int = 2,
                                  enable_learning_to_rank: bool = True,
                                  ):
@@ -96,7 +96,7 @@ def call_suggestions_by_category(label: str,
                 "max_per_type": max_per_type,
                 "max_recursive_related_collections": max_recursive_related_collections,
                 "max_related_collections": max_related_collections,
-                "name_diversity_ratio": name_diversity_ratio
+                "label_diversity_ratio": label_diversity_ratio
             },
             "wordplay": {
                 "max_suggestions": 10,
@@ -159,7 +159,7 @@ input = st.sidebar.text_input("Input:", value='zeus', key="input", on_change=res
 st.sidebar.slider('max_recursive_related_collections', 0, 10, 3, key='max_recursive_related_collections')
 st.sidebar.slider('max_related_collections', 0, 10, 6, key='max_related_collections')
 st.sidebar.toggle('enable_learning_to_rank', value=True, key='enable_learning_to_rank')
-st.sidebar.slider('name_diversity_ratio', 0.0, 1.0, 0.5, key='name_diversity_ratio')
+st.sidebar.slider('label_diversity_ratio', 0.0, 1.0, 0.5, key='label_diversity_ratio')
 st.sidebar.slider('max_per_type', 1, 5, 2, key='max_per_type')
 st.sidebar.header('Scramble')
 st.sidebar.selectbox("method", ("left-right-shuffle", "left-right-shuffle-with-unigrams", "full-shuffle"), index=1,
@@ -173,7 +173,7 @@ response = call_suggestions_by_category(
     input,
     max_recursive_related_collections=st.session_state.max_recursive_related_collections,
     max_related_collections=st.session_state.max_related_collections,
-    name_diversity_ratio=st.session_state.name_diversity_ratio,
+    label_diversity_ratio=st.session_state.label_diversity_ratio,
     max_per_type=st.session_state.max_per_type,
     enable_learning_to_rank=st.session_state.enable_learning_to_rank
 )

--- a/tests/load_tests/locust_suggestions_by_category.py
+++ b/tests/load_tests/locust_suggestions_by_category.py
@@ -22,7 +22,7 @@ request_data = {
             "max_per_type": 2,
             "max_recursive_related_collections": 3,
             "max_related_collections": 6,
-            "name_diversity_ratio": 0.5
+            "label_diversity_ratio": 0.5
         },
         "wordplay": {
             "max_suggestions": 10,

--- a/tests/load_tests/locust_suggestions_by_category_2.py
+++ b/tests/load_tests/locust_suggestions_by_category_2.py
@@ -1,0 +1,92 @@
+import copy
+import random
+
+from locust import HttpUser, between, task
+
+request_data = {
+    "label": '',
+    "params": {
+        "user_info": {
+            "user_wallet_addr": "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+            "user_ip_addr": "192.168.0.1",
+            "session_id": "d6374908-94c3-420f-b2aa-6dd41989baef",
+            "user_ip_country": "us"
+        },
+        "mode": "full",
+        "metadata": True
+    },
+    "categories": {
+        "related": {
+            "enable_learning_to_rank": True,
+            "max_names_per_related_collection": 10,
+            "max_per_type": 2,
+            "max_recursive_related_collections": 3,
+            "max_related_collections": 6,
+            "label_diversity_ratio": 0.5
+        },
+        "wordplay": {
+            "max_suggestions": 10,
+            "min_suggestions": 2
+        },
+        "alternates": {
+            "max_suggestions": 10,
+            "min_suggestions": 2
+        },
+        "emojify": {
+            "max_suggestions": 10,
+            "min_suggestions": 2
+        },
+        "community": {
+            "max_suggestions": 10,
+            "min_suggestions": 2
+        },
+        "expand": {
+            "max_suggestions": 10,
+            "min_suggestions": 2
+        },
+        "gowild": {
+            "max_suggestions": 10,
+            "min_suggestions": 2
+        },
+        "other": {
+            "max_suggestions": 10,
+            "min_suggestions": 6,
+            "min_total_suggestions": 50
+        }
+    }
+}
+
+input_names = ['cat', 'zeus']
+
+CAT = set(
+    ['mainecoon.eth', 'ragdoll.eth', 'ragdollcat.eth', 'siamesecat.eth', 'persiancat.eth', 'lambkin.eth', 'manxcat.eth', 'birman.eth', 'birmancat.eth', 'bombaycat.eth', 'aba.eth', 'abb.eth', 'abe.eth', 'abi.eth', 'abt.eth', 'abu.eth', 'aby.eth', 'ace.eth', 'acy.eth', 'ada.eth', 'spacejam.eth', 'tweetiepie.eth', 'kingtweety.eth', 'scaredycat.eth', 'canaryrow.eth', 'popimpop.eth', 'tweetyssos.eth', 'cannedfeud.eth', 'carrotblanca.eth', 'dogpounded.eth', 'maniac.eth', 'theblackcat.eth', 'twoevileyes.eth', 'talesofterror.eth', 'unheimlichegeschichten.eth', 'yourviceisalockedroomandonlyihavethekey.eth', 'adult.eth', 'porn.eth', 'sex.eth', 'xxx.eth', 'com.eth', 'icmregistry.eth', 'net.eth', 'onion.eth', 'org.eth', 'melbourne.eth', 'bengalcat.eth', 'sphynxcat.eth', 'tabbycat.eth', 'calicocat.eth', 'larry.eth', 'cremepuff.eth', 'blackcat.eth', 'kitten.eth', 'feralcat.eth', 'streetcat.eth', 'dog.eth', 'rabbit.eth', 'guy.eth', 'cats.eth', 'hombre.eth', 'kitty.eth', 'rat.eth', 'housemouse.eth', 'mouse.eth', 'bozo.eth', 'cat🐈.eth', 'cat🐈\u200d⬛.eth', 'cat🇺🇸.eth', 'cat🐱.eth', 'cat🐯.eth', 'cat💩.eth', 'cat😸.eth', 'cat😺.eth', '🇺🇸cat.eth', 'i❤cat.eth', 'dedicated.eth', 'incat.eth', 'notcat.eth', 'certification.eth', 'indicate.eth', 'indicates.eth', 'catalogue.eth', 'catservice.eth', 'bestcat.eth', 'catholic.eth', 'cats.eth', '$cat.eth', 'catgatt.eth', 'thecat.eth', '_cat.eth', 'ξcat.eth', 'cater.eth', 'catautocad.eth', '0xcat.eth', 'cat22.eth', 'c47.eth', 'tac.eth', 'ca7.eth'])
+ZEUS = set(
+    ['abaddon.eth', 'alchemist.eth', 'ancientapparition.eth', 'antimage.eth', 'arcwarden.eth', 'axe.eth', 'bane.eth', 'batrider.eth', 'beastmaster.eth', 'bloodseeker.eth', 'spiderman.eth', 'ironman.eth', 'thanos.eth', 'hulk.eth', 'wolverine.eth', 'doctordoom.eth', 'venom.eth', 'galactus.eth', 'janefoster.eth', 'titania.eth', 'rihanna.eth', 'willsmith.eth', 'kanyewest.eth', 'eminem.eth', 'miakhalifa.eth', 'beyonce.eth', 'snoopdogg.eth', 'johncena.eth', 'badbunny.eth', 'coolio.eth', 'aaba.eth', 'aal.eth', 'aame.eth', 'aaoi.eth', 'aaon.eth', 'aapl.eth', 'aaww.eth', 'aaxj.eth', 'aaxn.eth', 'abac.eth', 'cthulhu.eth', 'vecna.eth', 'thor.eth', 'azathoth.eth', 'aslan.eth', 'raiden.eth', 'beerus.eth', 'odin.eth', 'ares.eth', 'tiamat.eth', 'aphrodite.eth', 'apollo.eth', 'artemis.eth', 'tauropolia.eth', 'prometheus.eth', 'athena.eth', 'heracles.eth', 'hermes.eth', 'hades.eth', 'cronus.eth', 'hera.eth', 'hades.eth', 'poseidon.eth', 'odin.eth', 'cronus.eth', 'heracles.eth', 'persephone.eth', 'thor.eth', 'asgard.eth', 'darth.eth', 'zeus🇺🇸.eth', 'zeus💩.eth', '🆉🅴🆄🆂.eth', '🇺🇸zeus.eth', 'zeus💲.eth', 'zeus🐋.eth', 'zeus🐉.eth', '💎zeus.eth', '•zeus.eth', 'godzeus.eth', 'thezeus.eth', 'notzeus.eth', 'zeusfactory.eth', 'sonofzeus.eth', 'statueofzeus.eth', 'gameoverzeus.eth', 'zeusor.eth', 't1zeus.eth', 'hazeus.eth', '_zeus.eth', 'drzeus.eth', 'zeuser.eth', '$zeus.eth', 'zeusmorpheus.eth', 'realzeus.eth', 'thezeus.eth', 'mrzeus.eth', 'zeus-.eth', 'zeusamadeus.eth', '23v5.eth', 'suez.eth', '2ev5.eth'])
+
+class WebsiteUser(HttpUser):
+    wait_time = lambda x: 0.0  # between(1, 5)
+
+    URL = "/suggestions_by_category"
+
+    @task(5)
+    def suggestions_by_category(self):
+        json = copy.deepcopy(request_data)
+        json['label'] = random.choice(input_names) # + ' ' + str(random.randint(0, 1000000))
+        r = self.client.post(self.URL, name='suggestions_by_category', json=json)
+        # print(r.json())
+        response = r.json()
+        names = []
+        for category in response['categories']:
+            for suggestion in category['suggestions']:
+                # print(suggestion['name'])
+                names.append(suggestion['name'])
+        # print(json['label'], names)
+        if json['label'] == 'cat' and set(names) & ZEUS:
+            print(json['label'], names)
+        elif json['label'] == 'zeus' and set(names) & CAT:
+            print(json['label'], names)
+
+        # if json['label'] == 'cat' and set(names) != CAT:
+        #     print(json['label'], names)
+        # elif json['label'] == 'zeus' and set(names) != ZEUS:
+        #     print(json['label'], names)

--- a/tests/test_collections_api.py
+++ b/tests/test_collections_api.py
@@ -601,9 +601,9 @@ class TestCorrectConfiguration:
     @mark.integration_test
     def test_fetch_collection_members_tokenized_names(self, test_test_client):
         name2labeltokens = {
-            "dualipa.eth": ("dua", "lipa"),
-            "thebeatles.eth": ("the", "beatles"),
-            "davidbowie.eth": ("david", "bowie")
+            "dualipa": ("dua", "lipa"),
+            "thebeatles": ("the", "beatles"),
+            "davidbowie": ("david", "bowie")
         }
 
         response = test_test_client.post("/fetch_collection_members", json={
@@ -615,7 +615,7 @@ class TestCorrectConfiguration:
         assert response.status_code == 200
         response_json = response.json()
         for item in response_json['suggestions']:
-            assert ''.join(item['tokenized_label']) == item['name'].removesuffix('.eth')
+            assert ''.join(item['tokenized_label']) == item['name']
             if item['name'] in name2labeltokens:
                 assert tuple(item['tokenized_label']) == name2labeltokens[item['name']]
 

--- a/tests/test_collections_api.py
+++ b/tests/test_collections_api.py
@@ -92,6 +92,7 @@ class TestCorrectConfiguration:
         es_time = response_json['metadata'].get('elasticsearch_processing_time_ms', 0)
         assert es_time <= response_json['metadata']['processing_time_ms'] <= (t1 - t0) * 1000
 
+    @mark.skip(reason='we return only names, without the root name')
     @mark.integration_test
     def test_collection_api_eth_suffix(self, test_test_client):
         response = test_test_client.post("/find_collections_by_string", json={

--- a/tests/test_collections_api.py
+++ b/tests/test_collections_api.py
@@ -554,7 +554,7 @@ class TestCorrectConfiguration:
         response_json = response.json()
         
         assert len(response_json['suggestions']) == 10
-        assert response_json['type'] == 'related'
+        # assert response_json['type'] == 'related'  # we removed this field
         assert response_json['collection_id'] == 'ri2QqxnAqZT7'
         
         # Test fetching second page

--- a/tests/test_collections_api.py
+++ b/tests/test_collections_api.py
@@ -92,7 +92,7 @@ class TestCorrectConfiguration:
         es_time = response_json['metadata'].get('elasticsearch_processing_time_ms', 0)
         assert es_time <= response_json['metadata']['processing_time_ms'] <= (t1 - t0) * 1000
 
-    @mark.skip(reason='we return only names, without the root name')
+    @mark.skip(reason='we return only labels, without the root name')
     @mark.integration_test
     def test_collection_api_eth_suffix(self, test_test_client):
         response = test_test_client.post("/find_collections_by_string", json={
@@ -109,9 +109,9 @@ class TestCorrectConfiguration:
         response_json = response.json()
 
         assert len(response_json['related_collections'] + response_json['other_collections']) <= 5
-        assert all([member_name['name'].endswith('.eth')
+        assert all([member_name['label'].endswith('.eth')
                     for collection in response_json['related_collections'] + response_json['other_collections']
-                    for member_name in collection['top_names']])
+                    for member_name in collection['top_labels']])
 
     @mark.integration_test
     def test_collection_api_avatar_emojis_and_images(self, test_test_client):
@@ -153,7 +153,7 @@ class TestCorrectConfiguration:
             "max_total_collections": 15,
             "name_diversity_ratio": 0.5,
             "max_per_type": 3,
-            "limit_names": 10,
+            "limit_labels": 10,
         })
 
         assert response.status_code == 200
@@ -172,7 +172,7 @@ class TestCorrectConfiguration:
             "max_total_collections": 6,
             "name_diversity_ratio": 0.5,
             "max_per_type": 3,
-            "limit_names": 10,
+            "limit_labels": 10,
         })
 
         assert response.status_code == 200
@@ -190,7 +190,7 @@ class TestCorrectConfiguration:
             "max_total_collections": 100,
             "name_diversity_ratio": None,  # no diversity
             "max_per_type": None,
-            "limit_names": 10,
+            "limit_labels": 10,
             "sort_order": 'Z-A',  # sort
             "offset": 0,  # page 1
             "max_related_collections": 100,
@@ -207,7 +207,7 @@ class TestCorrectConfiguration:
             "max_total_collections": 100,
             "name_diversity_ratio": None,  # no diversity
             "max_per_type": None,
-            "limit_names": 10,
+            "limit_labels": 10,
             "sort_order": 'Z-A',  # sort
             "offset": 100,  # page 2
             "max_related_collections": 100,
@@ -269,7 +269,7 @@ class TestCorrectConfiguration:
         response = test_test_client.post("/find_collections_by_member", json={
             "label": "australia",
             "sort_order": "A-Z",
-            "limit_names": lim,
+            "limit_labels": lim,
             "mode": 'domain_detail',
             "offset": 10,
             'max_results': 30
@@ -279,8 +279,8 @@ class TestCorrectConfiguration:
         response_json = response.json()
         collection_list = response_json['collections']
 
-        # test limit names
-        assert all([len(c['top_names']) <= lim for c in collection_list])
+        # test limit labels
+        assert all([len(c['top_labels']) <= lim for c in collection_list])
 
         # test A-Z sort
         titles = [c['title'] for c in collection_list]
@@ -308,7 +308,7 @@ class TestCorrectConfiguration:
         response = test_test_client.post("/find_collections_by_member", json={
             "label": "softmachine",
             "mode": "domain_detail",
-            "limit_names": 10,
+            "limit_labels": 10,
             "sort_order": 'AI',  # sort
             "offset": 20,  # page out of bounds (offset >= n_matched_collections)
             "max_related_collections": 100,
@@ -331,7 +331,7 @@ class TestCorrectConfiguration:
             "max_total_collections": 10,
             "name_diversity_ratio": 0.5,
             "max_per_type": 3,
-            "limit_names": 10,
+            "limit_labels": 10,
             "sort_order": 'Relevance'
         })
 
@@ -351,7 +351,7 @@ class TestCorrectConfiguration:
             "min_other_collections": 0,
             "max_other_collections": 4,
             "max_total_collections": 10,
-            "limit_names": 6,
+            "limit_labels": 6,
             "offset": 8,
             "sort_order": 'A-Z'
         })
@@ -362,8 +362,8 @@ class TestCorrectConfiguration:
 
         collection_list = response_json['related_collections']
 
-        # test limit names
-        assert all([len(c['top_names']) <= 6 for c in collection_list])
+        # test limit labels
+        assert all([len(c['top_labels']) <= 6 for c in collection_list])
 
         # test A-Z sort
         titles = [c['title'] for c in collection_list]
@@ -383,7 +383,7 @@ class TestCorrectConfiguration:
             "max_total_collections": 6,
             "name_diversity_ratio": 0.5,
             "max_per_type": 3,
-            "limit_names": 10,
+            "limit_labels": 10,
         })
         assert response.status_code == 404
 
@@ -402,10 +402,10 @@ class TestCorrectConfiguration:
         assert response.status_code == 422
 
     @mark.integration_test
-    def test_collection_api_instant_search_limit_names_gt_10(self, test_test_client):
+    def test_collection_api_instant_search_limit_labels_gt_10(self, test_test_client):
         response = test_test_client.post("/find_collections_by_string", json={
             "query": "australia",
-            "limit_names": 11,
+            "limit_labels": 11,
         })
         assert response.status_code == 422
 
@@ -568,8 +568,8 @@ class TestCorrectConfiguration:
         response2_json = response2.json()
         
         # Verify different pages return different members
-        first_page_names = [s['name'] for s in response_json['suggestions']]
-        second_page_names = [s['name'] for s in response2_json['suggestions']]
+        first_page_names = [s['label'] for s in response_json['suggestions']]
+        second_page_names = [s['label'] for s in response2_json['suggestions']]
         assert not set(first_page_names).intersection(second_page_names)
 
     @mark.integration_test
@@ -600,7 +600,7 @@ class TestCorrectConfiguration:
 
     @mark.integration_test
     def test_fetch_collection_members_tokenized_names(self, test_test_client):
-        name2labeltokens = {
+        label2tokens = {
             "dualipa": ("dua", "lipa"),
             "thebeatles": ("the", "beatles"),
             "davidbowie": ("david", "bowie")
@@ -615,9 +615,9 @@ class TestCorrectConfiguration:
         assert response.status_code == 200
         response_json = response.json()
         for item in response_json['suggestions']:
-            assert ''.join(item['tokenized_label']) == item['name']
-            if item['name'] in name2labeltokens:
-                assert tuple(item['tokenized_label']) == name2labeltokens[item['name']]
+            assert ''.join(item['tokenized_label']) == item['label']
+            if item['label'] in label2tokens:
+                assert tuple(item['tokenized_label']) == label2tokens[item['label']]
 
     @mark.integration_test
     def test_get_collection_by_id(self, test_test_client):
@@ -630,9 +630,10 @@ class TestCorrectConfiguration:
         assert collection['collection_id'] == "ri2QqxnAqZT7"
         assert 'title' in collection
         assert 'owner' in collection
-        assert 'number_of_names' in collection
+        assert 'number_of_labels' in collection
         assert 'last_updated_timestamp' in collection
-        assert 'top_names' in collection
+        assert 'top_labels' in collection
+        assert all([tuple(label.keys()) == ('label',) for label in collection['top_labels']])
         assert 'types' in collection
         assert 'avatar_emoji' in collection
         assert 'avatar_image' in collection
@@ -677,7 +678,7 @@ class TestCollectionApiUnavailable:
             "min_other_collections": 0,
             "max_other_collections": 2,
             "max_total_collections": 10,
-            "limit_names": 6,
+            "limit_labels": 6,
             "offset": 8,
             "sort_order": 'A-Z'
         })

--- a/tests/test_collections_api.py
+++ b/tests/test_collections_api.py
@@ -102,7 +102,7 @@ class TestCorrectConfiguration:
             "max_total_collections": 5,
             "min_other_collections": 0,
             "max_other_collections": 0,
-            "name_diversity_ratio": None,  # no diversity
+            "label_diversity_ratio": None,  # no diversity
             "max_per_type": None,
         })
         assert response.status_code == 200
@@ -151,7 +151,7 @@ class TestCorrectConfiguration:
             "min_other_collections": 0,
             "max_other_collections": 15,
             "max_total_collections": 15,
-            "name_diversity_ratio": 0.5,
+            "label_diversity_ratio": 0.5,
             "max_per_type": 3,
             "limit_labels": 10,
         })
@@ -170,7 +170,7 @@ class TestCorrectConfiguration:
             "min_other_collections": 3,
             "max_other_collections": 3,
             "max_total_collections": 6,
-            "name_diversity_ratio": 0.5,
+            "label_diversity_ratio": 0.5,
             "max_per_type": 3,
             "limit_labels": 10,
         })
@@ -188,7 +188,7 @@ class TestCorrectConfiguration:
             "min_other_collections": 0,
             "max_other_collections": 0,
             "max_total_collections": 100,
-            "name_diversity_ratio": None,  # no diversity
+            "label_diversity_ratio": None,  # no diversity
             "max_per_type": None,
             "limit_labels": 10,
             "sort_order": 'Z-A',  # sort
@@ -205,7 +205,7 @@ class TestCorrectConfiguration:
             "min_other_collections": 0,
             "max_other_collections": 0,
             "max_total_collections": 100,
-            "name_diversity_ratio": None,  # no diversity
+            "label_diversity_ratio": None,  # no diversity
             "max_per_type": None,
             "limit_labels": 10,
             "sort_order": 'Z-A',  # sort
@@ -329,7 +329,7 @@ class TestCorrectConfiguration:
             "min_other_collections": 0,
             "max_other_collections": 0,
             "max_total_collections": 10,
-            "name_diversity_ratio": 0.5,
+            "label_diversity_ratio": 0.5,
             "max_per_type": 3,
             "limit_labels": 10,
             "sort_order": 'Relevance'
@@ -381,7 +381,7 @@ class TestCorrectConfiguration:
             "min_other_collections": 0,
             "max_other_collections": 3,
             "max_total_collections": 6,
-            "name_diversity_ratio": 0.5,
+            "label_diversity_ratio": 0.5,
             "max_per_type": 3,
             "limit_labels": 10,
         })

--- a/tests/test_name_generators.py
+++ b/tests/test_name_generators.py
@@ -538,8 +538,8 @@ def test_substringmatchgenerator_sorting():
         generated_names = list(strategy.generate(tokenized_name))
         generated_tokens = generated_names
 
-        assert ('00042069',) in generated_tokens  # interesting_score = 988
-        assert ('0000042069',) in generated_tokens  # interesting_score = 227
+        assert ('00042069',) in generated_tokens  # sort_score = 988
+        assert ('0000042069',) in generated_tokens  # sort_score = 227
 
         longer_pos = generated_tokens.index(('0000042069',))
         shorter_pos = generated_tokens.index(('00042069',))

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -37,7 +37,7 @@ def test_read_main(test_test_client):
     assert response.status_code == 200
 
     json = response.json()
-    str_names = [name["name"] for name in json]
+    str_names = [name['label'] for name in json]
     assert "discharge" in str_names
 
 
@@ -59,7 +59,7 @@ def test_metadata_scheme(test_test_client, name: str):
     json = response.json()
 
     for generated_name in json:
-        assert sorted(generated_name.keys()) == sorted(["name", "tokenized_label", "metadata"])
+        assert sorted(generated_name.keys()) == sorted(['label', "tokenized_label", "metadata"])
         assert sorted(generated_name["metadata"].keys()) == sorted([
             'applied_strategies', 'cached_interesting_score', 'cached_status',
             'categories', 'interpretation', 'pipeline_name', 'collection_title', 'collection_id', 'grouping_category'
@@ -94,7 +94,7 @@ def test_metadata_applied_strategies(test_test_client,
     print(json)
     print('==='*20)
 
-    result = [name for name in json if name["name"] == expected_name]
+    result = [name for name in json if name['label'] == expected_name]
 
     assert len(result) == 1
 
@@ -148,7 +148,7 @@ def test_length_sorter(test_test_client, name: str):
     json = response.json()
     assert len(json) > 0
 
-    lengths = [len(gn["name"]) for gn in json]
+    lengths = [len(gn['label']) for gn in json]
     assert all([first <= second for first, second in zip(lengths, lengths[1:])])
 
 
@@ -170,7 +170,7 @@ def test_min_max_suggestions_parameters(test_test_client, name: str, min_suggest
     assert response.status_code == 200
 
     json = response.json()
-    unique_names = set([suggestion["name"] for suggestion in json])
+    unique_names = set([suggestion['label'] for suggestion in json])
     assert len(unique_names) == len(json)
 
     assert min_suggestions <= len(unique_names)
@@ -187,7 +187,7 @@ def test_min_primary_fraction(test_test_client):
 
     json = response.json()
     assert len(json) > 0
-    names = [suggestion["name"] for suggestion in json]
+    names = [suggestion['label'] for suggestion in json]
     assert 'iref' not in names
 
 
@@ -232,6 +232,6 @@ def test_person_name_generator(test_test_client):
     assert response.status_code == 200
 
     json = response.json()
-    str_names = [name["name"] for name in json]
+    str_names = [name['label'] for name in json]
 
     assert "iamchris" in str_names

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -38,7 +38,7 @@ def test_read_main(test_test_client):
 
     json = response.json()
     str_names = [name["name"] for name in json]
-    assert "discharge.eth" in str_names
+    assert "discharge" in str_names
 
 
 @mark.parametrize(
@@ -70,7 +70,7 @@ def test_metadata_scheme(test_test_client, name: str):
     "name, expected_name, expected_strategies",
     [(
             "dogcat",
-            "catdog.eth",
+            "catdog",
             [
                 [
                     "PermuteGenerator", "SubnameFilter", "ValidNameFilter"
@@ -188,7 +188,7 @@ def test_min_primary_fraction(test_test_client):
     json = response.json()
     assert len(json) > 0
     names = [suggestion["name"] for suggestion in json]
-    assert 'iref.eth' not in names
+    assert 'iref' not in names
 
 
 # verifies whether only `RandomAvailableNameGenerator` has been used since it is specified as the only one, which can
@@ -234,4 +234,4 @@ def test_person_name_generator(test_test_client):
     json = response.json()
     str_names = [name["name"] for name in json]
 
-    assert "iamchris.eth" in str_names
+    assert "iamchris" in str_names

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -61,7 +61,7 @@ def test_metadata_scheme(test_test_client, name: str):
     for generated_name in json:
         assert sorted(generated_name.keys()) == sorted(['label', "tokenized_label", "metadata"])
         assert sorted(generated_name["metadata"].keys()) == sorted([
-            'applied_strategies', 'cached_interesting_score', 'cached_status',
+            'applied_strategies', 'cached_sort_score', 'cached_status',
             'categories', 'interpretation', 'pipeline_name', 'collection_title', 'collection_id', 'grouping_category'
         ])
 

--- a/tests/test_web_api_per_pipeline.py
+++ b/tests/test_web_api_per_pipeline.py
@@ -67,7 +67,7 @@ class TestFlagAffix:
         json = response.json()
         names: list[str] = [suggestion["name"] for suggestion in json]
 
-        assert any(name.endswith(expected_suffix + '.eth') for name in names)
+        assert any(name.endswith(expected_suffix) for name in names)
 
     def test_country_generator_parameter_no_country(self, test_client):
         client = test_client
@@ -153,7 +153,7 @@ class TestFlagAffix:
 
         json = response.json()
         names = [suggestion["name"] for category in json['categories'] for suggestion in category['suggestions']]
-        assert any(name.endswith(expected_suffix + '.eth') for name in names)
+        assert any(name.endswith(expected_suffix) for name in names)
 
 
 @mark.usefixtures("emoji_pipeline")
@@ -161,10 +161,10 @@ class TestEmoji:
     @mark.parametrize(
         "name, expected_names",
         [
-            ("adoreyoureyes", ["adoreyour👀.eth", "🥰youreyes.eth", "🥰your👀.eth"]),
-            ("prayforukraine", ["prayfor🇺🇦.eth", "🙏forukraine.eth", "🙏for🇺🇦.eth"]),
-            ("krakowdragon", ["krakow🐉.eth"]),
-            ("dragon", ["dragon🐉.eth"])
+            ("adoreyoureyes", ["adoreyour👀", "🥰youreyes", "🥰your👀"]),
+            ("prayforukraine", ["prayfor🇺🇦", "🙏forukraine", "🙏for🇺🇦"]),
+            ("krakowdragon", ["krakow🐉"]),
+            ("dragon", ["dragon🐉"])
         ]
     )
     def test_emoji_generator_api(self, test_client, name: str, expected_names: list[str]):
@@ -200,8 +200,8 @@ class TestOnlyPrimary:
         names: list[str] = [suggestion["name"] for suggestion in json]
 
         assert len(names) == 1
-        assert names[0] in {'glintpay.eth', 'drbaher.eth', '9852222.eth', 'wanadoo.eth',
-                            'conio.eth', 'indulgente.eth', 'theclown.eth', 'taco.eth'}
+        assert names[0] in {'glintpay', 'drbaher', '9852222', 'wanadoo',
+                            'conio', 'indulgente', 'theclown', 'taco'}
 
 
 @pytest.fixture(scope='class')
@@ -220,21 +220,21 @@ class TestSubstringMatch:
         assert response.status_code == 200
         json = response.json()
         names = [name["name"] for name in json]
-        assert "akamaihd.eth" in names
+        assert "akamaihd" in names
 
     def test_unnormalized(self, test_client):
         response = test_client.post("/", json={"label": "あかまい"})
         assert response.status_code == 200
         json = response.json()
         names = [name["name"] for name in json]
-        assert "あかまいhd.eth" in names
+        assert "あかまいhd" in names
 
     def test_emoji(self, test_client):
         response = test_client.post("/", json={"label": "💛"})
         assert response.status_code == 200
         json = response.json()
         names = [name["name"] for name in json]
-        assert "i💛you.eth" in names
+        assert "i💛you" in names
 
 
 @pytest.fixture(scope='class')
@@ -567,10 +567,10 @@ class TestGrouped:
         client = test_client
         collection_id = 'ri2QqxnAqZT7'  # Music artists and bands from England
 
-        name2labeltokens = {
-            "dualipa.eth": ("dua", "lipa"),
-            "thebeatles.eth": ("the", "beatles"),
-            "davidbowie.eth": ("david", "bowie")
+        label2tokens = {
+            "dualipa": ("dua", "lipa"),
+            "thebeatles": ("the", "beatles"),
+            "davidbowie": ("david", "bowie")
         }
 
         response = client.post("/fetch_top_collection_members",
@@ -581,9 +581,9 @@ class TestGrouped:
         assert len(response_json) <= 10
 
         for item in response_json['suggestions']:
-            assert ''.join(item['tokenized_label']) == item['name'].removesuffix('.eth')
-            if item['name'] in name2labeltokens:
-                assert tuple(item['tokenized_label']) == name2labeltokens[item['name']]
+            assert ''.join(item['tokenized_label']) == item['name']
+            if item['name'] in label2tokens:
+                assert tuple(item['tokenized_label']) == label2tokens[item['name']]
 
 
     @pytest.mark.xfail(reason="Enable when we move filtered collections to use a separate field") # TODO

--- a/tests/test_web_api_per_pipeline.py
+++ b/tests/test_web_api_per_pipeline.py
@@ -324,9 +324,9 @@ class TestGrouped:
         for label in ['pinkfloyd', 'spears', 'kyiv', 'ronaldo', 'bohr', 'buildings', 'births', 'deaths']:
             titles = []
             for diversity_parameters in [
-                {'name_diversity_ratio': 1.0, 'max_per_type': 1},
-                {'name_diversity_ratio': 0.5, 'max_per_type': 2},
-                {'name_diversity_ratio': None, 'max_per_type': None},
+                {'label_diversity_ratio': 1.0, 'max_per_type': 1},
+                {'label_diversity_ratio': 0.5, 'max_per_type': 2},
+                {'label_diversity_ratio': None, 'max_per_type': None},
             ]:
                 response = test_client.post("/suggestions_by_category", json={
                     "label": label,
@@ -374,7 +374,7 @@ class TestGrouped:
                     "max_per_type": 2,
                     "max_recursive_related_collections": 3,
                     "max_related_collections": 6,
-                    "name_diversity_ratio": 0.5
+                    "label_diversity_ratio": 0.5
                 },
                 "wordplay": {
                     "max_suggestions": 10,
@@ -501,7 +501,7 @@ class TestGrouped:
                     "max_per_type": 2,
                     "max_recursive_related_collections": 3,
                     "max_related_collections": 6,
-                    "name_diversity_ratio": 0.5
+                    "label_diversity_ratio": 0.5
                 },
             }
         }

--- a/tests/test_web_api_per_pipeline.py
+++ b/tests/test_web_api_per_pipeline.py
@@ -65,7 +65,7 @@ class TestFlagAffix:
         assert response.status_code == 200
 
         json = response.json()
-        names: list[str] = [suggestion["name"] for suggestion in json]
+        names: list[str] = [suggestion['label'] for suggestion in json]
 
         assert any(name.endswith(expected_suffix) for name in names)
 
@@ -82,7 +82,7 @@ class TestFlagAffix:
         })
         assert response.status_code == 200
         json = response.json()
-        names: list[str] = [suggestion["name"] for suggestion in json]
+        names: list[str] = [suggestion['label'] for suggestion in json]
         assert names
 
         response = client.post("/", json={
@@ -93,7 +93,7 @@ class TestFlagAffix:
         })
         assert response.status_code == 200
         json = response.json()
-        names: list[str] = [suggestion["name"] for suggestion in json]
+        names: list[str] = [suggestion['label'] for suggestion in json]
         assert names
 
         response = client.post("/", json={
@@ -104,7 +104,7 @@ class TestFlagAffix:
         })
         assert response.status_code == 200
         json = response.json()
-        names: list[str] = [suggestion["name"] for suggestion in json]
+        names: list[str] = [suggestion['label'] for suggestion in json]
         assert names
 
         response = client.post("/", json={
@@ -114,7 +114,7 @@ class TestFlagAffix:
         })
         assert response.status_code == 200
         json = response.json()
-        names: list[str] = [suggestion["name"] for suggestion in json]
+        names: list[str] = [suggestion['label'] for suggestion in json]
         assert names
 
         response = client.post("/", json={
@@ -123,7 +123,7 @@ class TestFlagAffix:
         })
         assert response.status_code == 200
         json = response.json()
-        names: list[str] = [suggestion["name"] for suggestion in json]
+        names: list[str] = [suggestion['label'] for suggestion in json]
         assert names
 
         response = client.post("/", json={
@@ -131,7 +131,7 @@ class TestFlagAffix:
         })
         assert response.status_code == 200
         json = response.json()
-        names: list[str] = [suggestion["name"] for suggestion in json]
+        names: list[str] = [suggestion['label'] for suggestion in json]
         assert names
 
     @mark.parametrize(
@@ -152,7 +152,7 @@ class TestFlagAffix:
         assert response.status_code == 200
 
         json = response.json()
-        names = [suggestion["name"] for category in json['categories'] for suggestion in category['suggestions']]
+        names = [suggestion['label'] for category in json['categories'] for suggestion in category['suggestions']]
         assert any(name.endswith(expected_suffix) for name in names)
 
 
@@ -172,7 +172,7 @@ class TestEmoji:
         assert response.status_code == 200
 
         json = response.json()
-        names: list[str] = [suggestion["name"] for suggestion in json]
+        names: list[str] = [suggestion['label'] for suggestion in json]
         print(names)
 
         assert set(expected_names).intersection(names) == set(expected_names)
@@ -197,7 +197,7 @@ class TestOnlyPrimary:
         assert response.status_code == 200
 
         json = response.json()
-        names: list[str] = [suggestion["name"] for suggestion in json]
+        names: list[str] = [suggestion['label'] for suggestion in json]
 
         assert len(names) == 1
         assert names[0] in {'glintpay', 'drbaher', '9852222', 'wanadoo',
@@ -219,21 +219,21 @@ class TestSubstringMatch:
         response = test_client.post("/", json={"label": "あかまい"})
         assert response.status_code == 200
         json = response.json()
-        names = [name["name"] for name in json]
+        names = [name['label'] for name in json]
         assert "akamaihd" in names
 
     def test_unnormalized(self, test_client):
         response = test_client.post("/", json={"label": "あかまい"})
         assert response.status_code == 200
         json = response.json()
-        names = [name["name"] for name in json]
+        names = [name['label'] for name in json]
         assert "あかまいhd" in names
 
     def test_emoji(self, test_client):
         response = test_client.post("/", json={"label": "💛"})
         assert response.status_code == 200
         json = response.json()
-        names = [name["name"] for name in json]
+        names = [name['label'] for name in json]
         assert "i💛you" in names
 
 
@@ -478,7 +478,7 @@ class TestGrouped:
         # no duplicated suggestions within categories
         related_suggestions = []
         for gcat in categories:
-            suggestions = [s['name'] for s in gcat['suggestions']]
+            suggestions = [s['label'] for s in gcat['suggestions']]
             print(gcat['type'], gcat['name'])
             print(suggestions)
             if gcat['type'] == 'related':
@@ -581,9 +581,9 @@ class TestGrouped:
         assert len(response_json) <= 10
 
         for item in response_json['suggestions']:
-            assert ''.join(item['tokenized_label']) == item['name']
-            if item['name'] in label2tokens:
-                assert tuple(item['tokenized_label']) == label2tokens[item['name']]
+            assert ''.join(item['tokenized_label']) == item['label']
+            if item['label'] in label2tokens:
+                assert tuple(item['tokenized_label']) == label2tokens[item['label']]
 
 
     @pytest.mark.xfail(reason="Enable when we move filtered collections to use a separate field") # TODO

--- a/tests/test_web_api_prod.py
+++ b/tests/test_web_api_prod.py
@@ -82,7 +82,7 @@ def test_prod(prod_test_client):
 
     json = response.json()
     str_names = [name["name"] for name in json]
-    assert "thefire.eth" in str_names
+    assert "thefire" in str_names
 
 
 @pytest.mark.execution_timeout(20)
@@ -117,7 +117,7 @@ def test_metadata(prod_test_client):
     json = response.json()
     assert len(json) > 0
     print(json)
-    catdog_result = [name for name in json if name["name"] == "catdog.eth"]
+    catdog_result = [name for name in json if name["name"] == "catdog"]
     assert len(catdog_result) == 1
 
 
@@ -206,7 +206,7 @@ def test_prod_leet(prod_test_client):
     json = response.json()
     str_names = [name["name"] for name in json]
 
-    assert "h4ck3r.eth" in str_names
+    assert "h4ck3r" in str_names
 
 
 @pytest.mark.slow
@@ -224,15 +224,15 @@ def test_prod_flag(prod_test_client):
     json = response.json()
     str_names = [name["name"] for name in json]
 
-    assert "firecar🇵🇱.eth" in str_names
-    assert "🇵🇱firecar.eth" in str_names
-    assert "_firecar.eth" in str_names
-    assert "$firecar.eth" in str_names
-    assert "fcar.eth" in str_names
-    assert "firec.eth" in str_names
-    assert "fire-car.eth" in str_names
-    # assert "🅵🅸🆁🅴🅲🅰🆁.eth" in str_names
-    assert "fir3c4r.eth" in str_names
+    assert "firecar🇵🇱" in str_names
+    assert "🇵🇱firecar" in str_names
+    assert "_firecar" in str_names
+    assert "$firecar" in str_names
+    assert "fcar" in str_names
+    assert "firec" in str_names
+    assert "fire-car" in str_names
+    # assert "🅵🅸🆁🅴🅲🅰🆁" in str_names
+    assert "fir3c4r" in str_names
 
 
 @pytest.mark.slow
@@ -355,7 +355,7 @@ def test_no_joined_input_as_suggestion(prod_test_client, input_label: str, joine
     response = client.post("/", json={"label": input_label, "metadata": True, "params": {"mode": "full"}})
 
     assert response.status_code == 200
-    assert joined_label + '.eth' not in [name["name"] for name in response.json()]
+    assert joined_label not in [name["name"] for name in response.json()]
 
 
 @pytest.mark.slow
@@ -633,7 +633,7 @@ class TestGroupedSuggestions:
             suggestions = [s['name'] for s in gcat['suggestions']]
 
             suggestion_tokens = [s['tokenized_label'] for s in gcat['suggestions']]
-            assert suggestions == list(map(lambda ts: ''.join(ts) + '.eth', suggestion_tokens))
+            assert suggestions == list(map(lambda ts: ''.join(ts), suggestion_tokens))
 
             print(gcat['type'], gcat['name'])
             print(suggestions)
@@ -885,7 +885,7 @@ def test_collection_members_sampling(prod_test_client, collection_id, max_sample
         assert name['metadata']['pipeline_name'] == 'sample_collection_members'
         assert name['metadata']['collection_id'] == collection_id
 
-        assert name['name'].removesuffix('.eth') == ''.join(name['tokenized_label'])
+        assert name['name'] == ''.join(name['tokenized_label'])
 
     # uniqueness
     names = [name['name'] for name in response_json]
@@ -963,8 +963,8 @@ class TestTokenScramble:
         for s in names:
             if s.startswith('egg'):
                 assert s[3:] in ('avocado', 'apple', 'fruit', 'coconut')
-            elif s.endswith('apple.eth'):
-                assert s[:-len('apple.eth')] in ('avocado', 'jack', 'coconut', 'egg')
+            elif s.endswith('apple'):
+                assert s[:-len('apple')] in ('avocado', 'jack', 'coconut', 'egg')
 
     @pytest.mark.integration_test
     def test_full_shuffle(self, prod_test_client):
@@ -1027,7 +1027,7 @@ class TestTokenScramble:
         assert response.status_code == 200
 
         for item in response.json():
-            assert ''.join(item['tokenized_label']) == item['name'].removesuffix('.eth')
+            assert ''.join(item['tokenized_label']) == item['name']
             assert len(item['tokenized_label']) == 2  # all scramble methods concatenate 2 tokens or multi-tokens
 
     @pytest.mark.integration_test

--- a/tests/test_web_api_prod.py
+++ b/tests/test_web_api_prod.py
@@ -962,7 +962,7 @@ class TestTokenScramble:
 
         for s in names:
             if s.startswith('egg'):
-                assert s[3:] in ('avocado.eth', 'apple.eth', 'fruit.eth', 'coconut.eth')
+                assert s[3:] in ('avocado', 'apple', 'fruit', 'coconut')
             elif s.endswith('apple.eth'):
                 assert s[:-len('apple.eth')] in ('avocado', 'jack', 'coconut', 'egg')
 

--- a/tests/test_web_api_prod.py
+++ b/tests/test_web_api_prod.py
@@ -81,7 +81,7 @@ def test_prod(prod_test_client):
     assert response.status_code == 200
 
     json = response.json()
-    str_names = [name["name"] for name in json]
+    str_names = [name['label'] for name in json]
     assert "thefire" in str_names
 
 
@@ -117,7 +117,7 @@ def test_metadata(prod_test_client):
     json = response.json()
     assert len(json) > 0
     print(json)
-    catdog_result = [name for name in json if name["name"] == "catdog"]
+    catdog_result = [name for name in json if name['label'] == "catdog"]
     assert len(catdog_result) == 1
 
 
@@ -139,7 +139,7 @@ def test_min_max_suggestions_parameters(prod_test_client, name: str, min_suggest
     assert response.status_code == 200
 
     json = response.json()
-    unique_names = set([suggestion["name"] for suggestion in json])
+    unique_names = set([suggestion['label'] for suggestion in json])
     assert len(unique_names) == len(json)
 
     assert min_suggestions <= len(unique_names)
@@ -170,7 +170,7 @@ def test_min_primary_fraction_parameters(prod_test_client, name: str, suggestion
 
     if response_code == 200:
         json = response.json()
-        unique_names = set([suggestion["name"] for suggestion in json])
+        unique_names = set([suggestion['label'] for suggestion in json])
         assert len(unique_names) == suggestions
 
 
@@ -204,7 +204,7 @@ def test_prod_leet(prod_test_client):
     assert response.status_code == 200
 
     json = response.json()
-    str_names = [name["name"] for name in json]
+    str_names = [name['label'] for name in json]
 
     assert "h4ck3r" in str_names
 
@@ -222,7 +222,7 @@ def test_prod_flag(prod_test_client):
     assert response.status_code == 200
 
     json = response.json()
-    str_names = [name["name"] for name in json]
+    str_names = [name['label'] for name in json]
 
     assert "firecar🇵🇱" in str_names
     assert "🇵🇱firecar" in str_names
@@ -247,7 +247,7 @@ def test_prod_short_suggestions(prod_test_client):
     assert response.status_code == 200
 
     json = response.json()
-    str_names = [name["name"] for name in json]
+    str_names = [name['label'] for name in json]
 
     assert all([len(name) >= 3 for name in str_names])
 
@@ -355,7 +355,7 @@ def test_no_joined_input_as_suggestion(prod_test_client, input_label: str, joine
     response = client.post("/", json={"label": input_label, "metadata": True, "params": {"mode": "full"}})
 
     assert response.status_code == 200
-    assert joined_label not in [name["name"] for name in response.json()]
+    assert joined_label not in [name['label'] for name in response.json()]
 
 
 @pytest.mark.slow
@@ -383,7 +383,7 @@ def test_prod_normalization_with_ens_normalize(prod_test_client):
                                      }})
 
         assert response.status_code == 200
-        str_names = [name["name"] for name in response.json()]
+        str_names = [name['label'] for name in response.json()]
         for name in str_names:
             assert is_ens_normalized(name), f'input name: "{input_name}"\tunnormalized suggestion: "{name}"'
 
@@ -630,7 +630,7 @@ class TestGroupedSuggestions:
         # no duplicated suggestions within categories
         related_suggestions = []
         for gcat in categories:
-            suggestions = [s['name'] for s in gcat['suggestions']]
+            suggestions = [s['label'] for s in gcat['suggestions']]
 
             suggestion_tokens = [s['tokenized_label'] for s in gcat['suggestions']]
             assert suggestions == list(map(lambda ts: ''.join(ts), suggestion_tokens))
@@ -710,7 +710,7 @@ class TestGroupedSuggestions:
         suggestions = []
         for gcat in categories:
             for suggestion in gcat['suggestions']:
-                suggestions.append(suggestion['name'])
+                suggestions.append(suggestion['label'])
 
         assert len(suggestions) == len(set(suggestions))
 
@@ -741,7 +741,7 @@ class TestGroupedSuggestions:
 
         for category in categories:
             print(category['name'])
-            print([s['name'] for s in category['suggestions']])
+            print([s['label'] for s in category['suggestions']])
             if category['type'] == 'emojify':
                 assert len(category['suggestions']) > 0  # Flag
             elif category['type'] == 'community':
@@ -885,10 +885,10 @@ def test_collection_members_sampling(prod_test_client, collection_id, max_sample
         assert name['metadata']['pipeline_name'] == 'sample_collection_members'
         assert name['metadata']['collection_id'] == collection_id
 
-        assert name['name'] == ''.join(name['tokenized_label'])
+        assert name['label'] == ''.join(name['tokenized_label'])
 
     # uniqueness
-    names = [name['name'] for name in response_json]
+    names = [name['label'] for name in response_json]
     assert len(names) == len(set(names))
 
 
@@ -934,7 +934,7 @@ class TestTokenScramble:
             assert name['metadata']['collection_id'] == collection_id
 
         # uniqueness
-        names = [name['name'] for name in response_json]
+        names = [name['label'] for name in response_json]
         assert len(names) == len(set(names))
 
     @pytest.mark.integration_test
@@ -957,7 +957,7 @@ class TestTokenScramble:
         # 3 bigrams + 2 unigrams, no max_suggestions -> no repeated tokens
         assert len(response_json) in (3, 4)  # (len can be 3 if 4th suggestion is an original name)
 
-        names = [name['name'] for name in response_json]
+        names = [name['label'] for name in response_json]
         assert len(names) == len(set(names))
 
         for s in names:
@@ -986,7 +986,7 @@ class TestTokenScramble:
         # 8 tokens -> 4 bigrams, max_suggestions=4 -> use repeated tokens if 4th suggestion is an original name
         assert len(response_json) == 4
 
-        names = [name['name'] for name in response_json]
+        names = [name['label'] for name in response_json]
         assert len(names) == len(set(names))
 
     @pytest.mark.integration_test
@@ -1006,7 +1006,7 @@ class TestTokenScramble:
         response_json = response.json()
         print(response_json)
 
-        names = [name['name'] for name in response_json]
+        names = [name['label'] for name in response_json]
         assert len(names) == len(set(names))
 
         assert len(names) == 40
@@ -1027,7 +1027,7 @@ class TestTokenScramble:
         assert response.status_code == 200
 
         for item in response.json():
-            assert ''.join(item['tokenized_label']) == item['name']
+            assert ''.join(item['tokenized_label']) == item['label']
             assert len(item['tokenized_label']) == 2  # all scramble methods concatenate 2 tokens or multi-tokens
 
     @pytest.mark.integration_test
@@ -1057,10 +1057,10 @@ class TestTokenScramble:
 
         response = client.post("/scramble_collection_tokens", json=request_json)
         assert response.status_code == 200
-        names1 = [name['name'] for name in response.json()]
+        names1 = [name['label'] for name in response.json()]
 
         response = client.post("/scramble_collection_tokens", json=request_json)
         assert response.status_code == 200
-        names2 = [name['name'] for name in response.json()]
+        names2 = [name['label'] for name in response.json()]
 
         assert names1 == names2

--- a/tests/test_web_api_prod.py
+++ b/tests/test_web_api_prod.py
@@ -534,7 +534,7 @@ class TestGroupedSuggestions:
                     "max_per_type": 2,
                     "max_recursive_related_collections": 3,
                     "max_related_collections": 6,
-                    "name_diversity_ratio": 0.5
+                    "label_diversity_ratio": 0.5
                 },
                 "wordplay": {
                     "max_suggestions": 10,
@@ -667,7 +667,7 @@ class TestGroupedSuggestions:
                     "max_per_type": 2,
                     "max_recursive_related_collections": 3,
                     "max_related_collections": 6,
-                    "name_diversity_ratio": 0.5
+                    "label_diversity_ratio": 0.5
                 },
                 "wordplay": {
                     "max_suggestions": 10,

--- a/web_api.py
+++ b/web_api.py
@@ -356,16 +356,14 @@ def convert_to_collection_format(collections: list[Collection]):
     return collections_json
 
 
-def convert_related_to_grouped_suggestions_format_for_collections(
+def convert_related_to_suggestions_from_collection_format(
         related_suggestions: RelatedSuggestions,
         include_metadata: bool = True
-) -> list[dict]:
+) -> dict:
     converted_suggestions = convert_to_suggestion_format(related_suggestions, include_metadata=True)
     return {
         'suggestions': converted_suggestions if include_metadata else
             [{k: v for k, v in sug.items() if k != 'metadata'} for sug in converted_suggestions],
-        'type': 'related',  # todo: remove field
-        'name': related_suggestions.collection_title,  # todo: remove field
         'collection_title': related_suggestions.collection_title,
         'collection_id': related_suggestions.collection_id,
         'collection_members_count': related_suggestions.collection_members_count,
@@ -425,7 +423,7 @@ async def fetch_top_collection_members(fetch_top10_command: Top10CollectionMembe
     rs.related_collections = result['related_collections']
     rs.extend(top_members)
 
-    response = convert_related_to_grouped_suggestions_format_for_collections(rs, include_metadata=fetch_top10_command.metadata)
+    response = convert_related_to_suggestions_from_collection_format(rs, include_metadata=fetch_top10_command.metadata)
 
     logger.info(json.dumps({'endpoint': 'fetch_top_collection_members', 'request': fetch_top10_command.model_dump()}))
 
@@ -664,7 +662,7 @@ async def fetch_collection_members(fetch_command: FetchCollectionMembersRequest)
                            result['collection_members_count'])
     rs.extend(members)
 
-    response = convert_related_to_grouped_suggestions_format_for_collections(rs, include_metadata=fetch_command.metadata)
+    response = convert_related_to_suggestions_from_collection_format(rs, include_metadata=fetch_command.metadata)
 
     logger.info(json.dumps({
         'endpoint': 'fetch_collection_members', 

--- a/web_api.py
+++ b/web_api.py
@@ -124,12 +124,10 @@ from collection_models import (
 
 def convert_to_suggestion_format(
         names: List[GeneratedName],
-        include_metadata: bool = True,
-        append_eth: bool = True
+        include_metadata: bool = True
 ) -> list[dict[str, str | dict]]:
     response = [{
-        'name': str(name) + ('.eth' if append_eth else ''),
-        # TODO this should be done using Domains (with or without duplicates if multiple suffixes available for one label?)
+        'name': str(name),
         'tokenized_label': list(name.tokens)
     } for name in names]
 
@@ -184,12 +182,11 @@ category_fancy_names = {
 
 def convert_related_to_grouped_suggestions_format(
         related_suggestions: dict[str, RelatedSuggestions],
-        include_metadata: bool = True,
-        append_eth: bool = True
+        include_metadata: bool = True
 ) -> list[dict]:
     grouped_response = []
     for collection_key, suggestions in related_suggestions.items():
-        converted_suggestions = convert_to_suggestion_format(suggestions, include_metadata=True, append_eth=append_eth)
+        converted_suggestions = convert_to_suggestion_format(suggestions, include_metadata=True)
         grouped_response.append({
             'suggestions': converted_suggestions if include_metadata else
             [{k: v for k, v in sug.items() if k != 'metadata'} for sug in converted_suggestions],
@@ -351,7 +348,7 @@ async def sample_collection_members(sample_command: SampleCollectionMembers):
         obj.interpretation = []
         sampled_members.append(obj)
 
-    response = convert_to_suggestion_format(sampled_members, include_metadata=sample_command.metadata, append_eth=False)
+    response = convert_to_suggestion_format(sampled_members, include_metadata=sample_command.metadata)
 
     logger.info(json.dumps({'endpoint': 'sample_collection_members', 'request': sample_command.model_dump()}))
 
@@ -385,8 +382,7 @@ async def fetch_top_collection_members(fetch_top10_command: Top10CollectionMembe
     rs.extend(top_members)
 
     response2 = convert_related_to_grouped_suggestions_format({result['collection_title']: rs},
-                                                              include_metadata=fetch_top10_command.metadata,
-                                                              append_eth=False)
+                                                              include_metadata=fetch_top10_command.metadata)
 
     logger.info(json.dumps({'endpoint': 'fetch_top_collection_members', 'request': fetch_top10_command.model_dump()}))
 
@@ -411,7 +407,7 @@ async def scramble_collection_tokens(scramble_command: ScrambleCollectionTokens)
         obj.interpretation = []
         suggestions.append(obj)
 
-    response = convert_to_suggestion_format(suggestions, include_metadata=scramble_command.metadata, append_eth=False)
+    response = convert_to_suggestion_format(suggestions, include_metadata=scramble_command.metadata)
 
     logger.info(json.dumps({'endpoint': 'scramble_collection_tokens', 'request': scramble_command.model_dump()}))
 
@@ -648,8 +644,7 @@ async def fetch_collection_members(fetch_command: FetchCollectionMembersRequest)
 
     response = convert_related_to_grouped_suggestions_format(
         {result['collection_title']: rs},
-        include_metadata=fetch_command.metadata,
-        append_eth=False
+        include_metadata=fetch_command.metadata
     )
 
     logger.info(json.dumps({

--- a/web_api.py
+++ b/web_api.py
@@ -137,7 +137,7 @@ def convert_to_suggestion_format(
         for name, name_json in zip(names, response):
             name_json['metadata'] = {
                 'applied_strategies': name.applied_strategies,
-                'cached_interesting_score': domains.get_interesting_score(name),
+                'cached_sort_score': domains.get_sort_score(name),
                 'cached_status': name.status,
                 'categories': categories.get_categories(str(name)),
                 'interpretation': name.interpretation,
@@ -469,7 +469,7 @@ async def find_collections_by_string(query: CollectionSearchByString):
             max_related_collections=query.max_related_collections,
             offset=query.offset,
             sort_order=query.sort_order,
-            name_diversity_ratio=query.name_diversity_ratio,
+            label_diversity_ratio=query.label_diversity_ratio,
             max_per_type=query.max_per_type,
             limit_names=query.limit_labels,
         )
@@ -540,7 +540,7 @@ async def find_collections_by_collection(query: CollectionSearchByCollection):
     related_collections, es_search_metadata = collections_matcher.search_by_collection(
         query.collection_id,
         max_related_collections=query.max_related_collections,
-        name_diversity_ratio=query.name_diversity_ratio,
+        label_diversity_ratio=query.label_diversity_ratio,
         max_per_type=query.max_per_type,
         limit_names=query.limit_labels,
         sort_order=query.sort_order,

--- a/web_api.py
+++ b/web_api.py
@@ -98,16 +98,13 @@ categories = Categories(generator.config)
 from models import (
     NameRequest,
     Suggestion,
-    SampleCollectionMembers,
     GroupedSuggestions,
-    Top10CollectionMembersRequest,
     GroupedNameRequest,
-    ScrambleCollectionTokens,
-    CollectionCategory,
-    FetchCollectionMembersRequest,
 )
 
 from collection_models import (
+    SuggestionFromCollection,
+    CollectionWithSuggestions,
     CollectionSearchResponse,
     CollectionSearchByCollection,
     CollectionSearchByString,
@@ -117,14 +114,18 @@ from collection_models import (
     CollectionsContainingNameResponse,
     CollectionCountByStringRequest,
     Collection as CollectionModel,
+    FetchCollectionMembersRequest,
     GetCollectionByIdRequest,
+    SampleCollectionMembers,
+    ScrambleCollectionTokens,
+    Top10CollectionMembersRequest,
 )
 
 
 def convert_to_suggestion_format(
         names: List[GeneratedName],
         include_metadata: bool = True,
-        append_eth=True
+        append_eth: bool = True
 ) -> list[dict[str, str | dict]]:
     response = [{
         'name': str(name) + ('.eth' if append_eth else ''),
@@ -331,7 +332,7 @@ def suggestions_by_category(name: GroupedNameRequest):
     return response
 
 
-@app.post("/sample_collection_members", response_model=list[Suggestion], tags=['collections'])
+@app.post("/sample_collection_members", response_model=list[SuggestionFromCollection], tags=['collections'])
 async def sample_collection_members(sample_command: SampleCollectionMembers):
     result, es_response_metadata = generator_matcher.sample_members_from_collection(
         sample_command.collection_id,
@@ -357,7 +358,7 @@ async def sample_collection_members(sample_command: SampleCollectionMembers):
     return response
 
 
-@app.post("/fetch_top_collection_members", response_model=CollectionCategory, tags=['collections'])
+@app.post("/fetch_top_collection_members", response_model=CollectionWithSuggestions, tags=['collections'])
 async def fetch_top_collection_members(fetch_top10_command: Top10CollectionMembersRequest):
     """
     * this endpoint returns top 10 members from the collection specified by collection_id
@@ -392,7 +393,7 @@ async def fetch_top_collection_members(fetch_top10_command: Top10CollectionMembe
     return response2[0]
 
 
-@app.post("/scramble_collection_tokens", response_model=list[Suggestion], tags=['collections'])
+@app.post("/scramble_collection_tokens", response_model=list[SuggestionFromCollection], tags=['collections'])
 async def scramble_collection_tokens(scramble_command: ScrambleCollectionTokens):
     result, es_response_metadata = generator_matcher.scramble_tokens_from_collection(
         scramble_command.collection_id, scramble_command.method,
@@ -618,7 +619,7 @@ async def find_collections_membership_list(request: CollectionsContainingNameReq
     return {'collections': collections, 'metadata': metadata}
 
 
-@app.post("/fetch_collection_members", response_model=CollectionCategory, tags=['collections'])
+@app.post("/fetch_collection_members", response_model=CollectionWithSuggestions, tags=['collections'])
 async def fetch_collection_members(fetch_command: FetchCollectionMembersRequest):
     """
     Fetch members from a collection with pagination support


### PR DESCRIPTION
Story details: https://app.shortcut.com/ps-web3/story/26070


TODO:
- [x] Disable adding `.eth` for Collections API
- [x] Disable adding `.eth` for Suggestions/Generator API
- [x] Refactor models
- [x] Implement separate response formatting functions for Collections API
- [x] Remove namehash field from `CollectionLabel`